### PR TITLE
[draft] Initial RFC on game structure and repo convention docs (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,226 @@
-# The Tungast of Oakshaw
+# The Tūn-Gāst of Oakshaw
+
+Welcome to the TGO repository! This document attempts to hit the high points of
+contributing to the codebase and should help you figure out how work through
+any confusion that might arise during the devoplment process.
+
+- [The Tūn-Gāst of Oakshaw](#the-tūn-gāst-of-oakshaw)
+  - [I'm not on the engineering team, does this matter to me?](#im-not-on-the-engineering-team-does-this-matter-to-me)
+  - [People](#people)
+    - [Questions?](#questions)
+  - [Process](#process)
+    - [Conventions: Ownership](#conventions-ownership)
+    - [Coventions: Code](#coventions-code)
+    - [Conventions: Git](#conventions-git)
+      - [`release`](#release)
+      - [`tgo_dev`](#tgo_dev)
+      - [Code Review](#code-review)
+        - [For non-engineering submissions](#for-non-engineering-submissions)
+      - [Release Candidate branches / bug fixes](#release-candidate-branches--bug-fixes)
+      - [Feature / Personal branches](#feature--personal-branches)
+  - [What next?](#what-next)
+
+## I'm not on the engineering team, does this matter to me?
+Kind of!
+
+You should definitely understand the golden rules:
+1. Don't commit to `release` branch
+2. Don't force push to `release` or `tgo_dev`
+
+Otherwise mostly check out [this section](#for-non-engineering-submissions) and chat
+with your lead to understand any discipline specific guidance.
+
+If you or your lead have any questions drop by #tgo-programming. We're friendly and
+would love to help.
+
+> TODO: Does it make sense to break stuff&mdash;including all the eng-focused
+> commentary&mdash;into pillar specific onboarding docs at this point?
  
+## People
+This is a large project! a full org chart is [available here][orgchart] but some
+the relevant leads:
+  - Ahria (discord: `katamahri`) &mdash; Engineering (that's us!)
+  - Stephen &mdash; Technical Narrative
+  - Mario &mdash; Game Design
+  - Keumars &mdash; Creative Director
+  - Marlo &mdash; Technical Producer
+
+### Questions?
+If something is unclear at any point in time feel free to ask around
+#tgo-programming or contact a lead to help guide you to the correct person/place
+for more info.
+
+## Process
+While the whole TGO team is large our engineering team is small and it's likely
+we'll each end up owning major parts of the game _and_ working in each other's
+domains if we want to make good time.
+
+In order to maintain awareness of what's going on outside our eng focus we:
+- have a weekly sync meeting. Notes are kept [here][team-standup]
+- track active work on a [kanban board in Notion][kanban]
+- communicate regularly in the #tgo-programming channel
+
+### Conventions: Ownership
+
+We hint at this above but it is likely each one of us will end up being the single
+biggest voice in the room for a one or more section of the code. Currently it looks
+like that will be:
+
+- Den: UI
+- Lent: Dialogic integration
+- Luke: Level loading / implementation & grayboxing
+- Envy: Player interaction mechanics
+
+This list is neither exhaustive nor final. You will always have an opportunity to
+change this and it explicitly **does not** mean that you will have to do all the
+related work on your own.
+
+It only means you are the person most likely to have a full understanding of the
+related systems and when we need more hands on a specific system it may fall to
+you to help understand how to decompose the problem or debug a particularly tricky
+issue.
+
+As a team we should aim to:
+1. Never let somebody own something by accident or implicitly;
+2. Not silently abandon something that we own;
+3. Understand when something doesn't have an owner.
+
+### Coventions: Code
+- GDScript should pass lint before merge. We have the repo set up to run a CI job
+  and check validity using `gdlint`. More info can be found about the errors it
+  reports and how to set up exclusions on [the wiki][gdlint-wiki]. Pre-commit hooks
+  to run locally on merge or a docker file to run locally should be coming "soon"
+  but are not in place yet
+- GDScript should format tests cleanly before merge. In order to reduce merge issues
+  we use an automated tool `gdformat` to ensure our code conforms to a consistent
+  formatting spec. Details on this are available on [the wiki][gdformat-wiki].
+  Pre-commit / docker jobs to run thees locally should be available "soon" but are
+  not in place yet.  
+  **_TODO:_ We also do not have this CI job configured yet so this is an optimistic plan**
+- We currently require [static typing][static-typing-docs] and non-typed variable
+  declarations will be reported as an error. There are several benefits of this
+    - Code maintainability &mdash; static typing is a compiler-enforced contract of
+      your intent. Its accuracy will never decay and it tells the future reader what
+      to expect without requiring them to fully understand function internals;
+    - Transferability &mdash; a secret power of staticly typed codebases is the reduced
+      cognitive load when trying to modify or contribute to code that you did not
+      write. This is highly related to maintainability but is not the same;
+    - Reduced reliance on tests &mdash; building with a dynamically typed codebase means
+      you can take many more liberties with your functions, how they're used, and how
+      they behave. This means that the surface area for bugs / mistakes is larger
+      and that the factors you need to consider when making changes is significantly
+      higher and (often) not obvious. This can be totally fine but in order to have
+      high confidence in behavior it requires an extremely solid test suite. Using
+      a statically typed language helps ameliorate the surface area and means we
+      can maintain high confidence on function behavior without as aggressive of a test
+      suite;
+    - Performance &mdash; using statically typed gdscript is between [5 and 150% faster][static-typed-perf]
+      than dynamically typed code. And it can get better as VM optimizations are done
+      by the Godot team.
+
+### Conventions: Git
+
+At the moment all these are guidelines and will be enforced via honor system.
+Locking the repo down would be a lot of headache and require paying to upgrade
+to GH enterprise or moving the repo to a personal account which complicates team
+management. So let's be honorable and save that effort :heart:.
+
+The most important rule, everything else we can mostly fix after the fact:
+
+**Do not force push changes to `release` or `tgo_dev`.**
+
+#### `release`
+Generally we will not be merging into the `release` branch going forward. It is
+reserved for near release quality code that has passed basic testing and will
+be going through a QA process for approval.
+
+#### `tgo_dev`
+Sprint / feature work will be merged into this branch and it's where most active
+development will happen. A merge to tgo_dev should:
+
+- first be presented as a PR with a meaningful description that will help reviewers
+  understand the changes being made and provide meaningful commentary
+- pass any CI tests that have been configured
+- once approved the **PR should be squashed** instead of standard merge. This helps keep
+  the `tgo_dev` branch clean and orderly
+
+#### Code Review
+We understand this is a volunteer project and it may not always be possible for
+a PR to receive a full and thorough review in a timely manner. The suggested
+process when trying to merge new code to tgo_dev will be:
+
+1. Initiate the PR and do a self-review: re-read the code with an eye for things that
+   may be done better, ensure CI passes, and provide a write-up for the changes being
+   merged.
+2. Post a link to your PR in #tgo-programming and give folks ~48 hours to get a chance
+   to read through it and provide feedback.
+3. If you haven't seen anybody indicate they've started looking at your review within 48h
+   feel free to post a note in channel and squash-merge it into `tgo_dev`.
+
+**Notes / exceptions:**  
+- For PRs that need an expedited review tag Ahria or envy in #tgo-programming when you
+have a PR ready and we'll try to help make sure we can keep things speedy without
+compromising code quality.
+- For minor changes (an, admittedly, subjective assessment) include a `[minor]`
+indicator in your PR title and feel free to merge without the 48h waiting period
+but do go through the PR process & writeup so that we have a full history of what
+got merged and why
+- For particularly complicated / expansive changes please do not merge without review. If
+you need attention on the PR tag Ahria or envy in #tgo-programming.
+
+##### For non-engineering submissions
+Most of above process is focused on **GDScript and technical changes** but
+at least initially the repository contains work including assets, dialogue,
+etc.
+
+Those changes should be considered out of scope for this document and should
+follow a process appropriate for that discipline and defined by the corresponding
+lead.
+
+#### Release Candidate branches / bug fixes
+This is not super well defined but when we merge a release candidate to `release`
+any bugs found will be fixed in a RC branch cut off release.
+
+As changes are made in that RC branch they should be back ported to tgo_dev.
+RC branches **should not** be merged back into release or subsequent tgo_dev->release
+merges will be problematic.
+
+#### Feature / Personal branches
+
+When doing development on a specific feature you should start your branch off the
+most recent `tgo_dev` commit. As time passes your branch will fall "behind" the
+`tgo_dev` branch off which it was based. As that happens it's suggested you
+pull `tgo_dev` and then merge that into your branch. This helps reduce conflict
+when it's time for your feature to be submitted to `tgo_dev`.
+
+Generally speaking you should cut a new branch for each new feature and retire that
+branch when you have completed the work you were doing. For example if I wanted to
+implement a new feature for a level I would:
+
+1. branch off `tgo_dev` and give my branch the name `envy-feature-name`
+2. do the work making commits as needed
+3. occasionally update my local view of `tgo_dev` and merge that into `envy-feature-name`
+4. When I'm done I would create a new PR to merge `envy-feature-name` into `tgo_dev`
+5. Once I have completed any PR feedback and gotten an approval to merge I would
+   squash-merge that back into tgo_dev
+6. I would then delete the branch `envy-feature-name` because it's all been submitted
+
+If I wanted to do a new bit of development I would repeat the process but use a new branch
+name that accurately reflects what I'm working on.
+
+There are essentially no rules on what you can do on your own branch.
+
+## What next?
+
+The `./docs` directory has a deep dive on various systems as well as broader
+structural decisions.
+
+Start [here](./docs/README.md).
+
+[orgchart]: https://miro.com/app/board/uXjVK-8EE4Y=/
+[team-standup]: https://www.notion.so/najmetender/38e72706e6ce4bdeb977e9f4e70bfae0?v=0f1a78091b19463baf1c21d8987063bd&pvs=4
+[kanban]: https://www.notion.so/najmetender/ce42775084b1437d94e334a5c46bc3ad?v=57c5260f242e45729fe4ebb09089d645
+[gdlint-wiki]: https://github.com/Scony/godot-gdscript-toolkit/wiki/3.%20Linter
+[gdformat-wiki]: https://github.com/Scony/godot-gdscript-toolkit/wiki/4.%20Formatter
+[static-typing-docs]: https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/static_typing.html
+[static-typed-perf]: https://godotengine.org/article/gdscript-progress-report-typed-instructions/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Welcome to TGO ./docs
+
+Here you'll find a starting point to some deep-dives on specific systems
+or design decisions.
+
+### [Game state management / general architecture](./tgo-arch.md)
+### [Dialogic](./tgo-dialogic.md)
+### [Audio](./tgo-audio.md)
+### [Game State Persistence](./tgo-save-load.md)
+### [Maps, Levels, and Objects. Oh My!](./tgo-levels.md)

--- a/docs/tgo-arch.md
+++ b/docs/tgo-arch.md
@@ -1,0 +1,187 @@
+# Building TGO
+
+- [Building TGO](#building-tgo)
+  - [Goal](#goal)
+  - [Changelog](#changelog)
+  - [Dataflow / Signals / Interfaces.](#dataflow--signals--interfaces)
+  - [**Prospective** Scene Tree](#prospective-scene-tree)
+  - [Scene Tree Details](#scene-tree-details)
+    - [Driver](#driver)
+    - [AudioManager](#audiomanager)
+    - [OverlayManager](#overlaymanager)
+      - [Curtain/HUD/Journal/Dialogue/Menus](#curtainhudjournaldialoguemenus)
+    - [GameWorld](#gameworld)
+      - [Clock](#clock)
+      - [Inventory](#inventory)
+      - [LevelManager](#levelmanager)
+      - [Player](#player)
+        - [Lamp](#lamp)
+        - [\<OtherItems\>](#otheritems)
+      - [LevelSegment](#levelsegment)
+        - [Placeables](#placeables)
+
+## Goal
+In this document I want to lay out the very high level approach we will take to
+tying major systems together in TGO. It is written aspirationally and without
+having encountered what I'm sure to be very real challenges along the path to
+implementation.
+
+To the degree that is possible we should strive to keep it updated but make
+sure to check the changelog and the farther in the past it is the more likely
+it's hiding dragons.
+
+## Changelog
+- 2024-07-09: Initial draft. Wish us luck.
+
+## Dataflow / Signals / Interfaces.
+
+Some very general rules:
+
+1. A parent may call into their children
+2. A child should signal up to the parent and should _not_ call methods via `get_parent()`
+3. A node should avoid direct access to its sibling (e.g. another child of their parent)
+4. Nodes that require initialization should expose a `setup` function that takes the
+   required objects and have those objects provided by the parent if it is added to
+   the scene tree via code.
+5. Driver should strive to be the only true singleton.
+
+We'll expand/revise these as we research/discover best practices.
+
+## **Prospective** Scene Tree
+
+Let's take a quick look at how the TGO Driver will be structured and a quick
+summary of the what/why for each major slice.
+
+```
+Driver
+├─ AudioManager
+├─ OverlayManager
+│  ├─ Curtain
+│  ├─ HUD
+│  ├─ Journal
+│  ├─ Dialogue
+│  └─ Menus
+└─ GameWorld
+   ├─ Clock
+   ├─ Inventory
+   └─ LevelManager
+      ├─ Player
+      │  ├─ Lamp
+      │  └─ <OtherItems>
+      └─ LevelSegment
+         └─ Placeables
+```
+
+## Scene Tree Details
+
+> :warning: Note that the farther down this list you go the less
+> well defined the information we have is to inform the design.
+> Expect things to change and, if you're the one changing them,
+> please update the doc for your team.
+
+### Driver
+
+This handles bootstrapping the game through initial setup and getting us to a
+start menu.
+
+It will also handle distribution of global state changes via defined signals
+(e.g., the game becomes paused) and provides an API to orchestrate broad multi-component
+functions (e.g., initiating a save/load).
+
+It is a singleton and provides access to attached managers. Each of the managers
+should rely only on API/signals from the Driver and should take a Driver reference
+to enable testing with stubs should we decide it necessary.
+
+### AudioManager
+
+Initially this will drive background music playback to enable easy transition
+between relevant tracks as we move between modes in the game (menus,
+dialogue, cutscenes, gameplay). Sound effects will live on the corresponding
+objects.
+
+Eventually this will be the central location for configuration and bootstrapping
+of any middleware we use and we'll refactor any exposed API for music controls to
+utilize the middleware system.
+
+### OverlayManager
+
+All UI that is presented not as part of the game world will end up a child here.
+Basically those scenes have a different coordinate system not impacted by player/camera
+movement and their z-order is detached from that of the rest of the game.
+
+It exposes an API that lets us request specific actions (Open Journal, Start Dialogue,
+etc) and exports signals indicating overlay start/stop states so that any gameplay
+related interfaces can take appropriate actions.
+
+#### Curtain/HUD/Journal/Dialogue/Menus
+
+A non exhaustive list of things I expect will be added to a UI overlay:
+
+- **Curtain**: can be used as a high z-order opaque screen to facilitate easy transitions
+- **HUD**: displays stat bars, active items, etc. Likely contains references to the GameWorld, Player, etc.
+- **Journal**: details unknown but primary information management mechanic
+- **Dialogue**: interaction point for triggering conversations
+- **Menus**: A catch-all for whatever menus we'll have available. May be a top-level MenuManager or we may have entries for each menu. TBD
+
+### GameWorld
+
+Stores all durable state about the game world. Anything that needs to persist
+between specific levels/maps being loaded should have representation here.
+
+Likely contains majority of game save/load logic.
+
+#### Clock
+
+In the event we run a day/night cycle this will handle the world clock's tick
+rate and contain signals indicating important times (day, dusk, night) as well
+as any global color grading/overlays associated with time of day.
+
+#### Inventory
+
+Data model for what the Player has available to them. De-coupled from the UI
+representation but can fire signals as state changes.
+
+Plausibly covers gear / equipment state.
+
+#### LevelManager
+
+Details currently unknown but this is a stand-in for something orchestrating
+a visual representation of the world that Devin is currently exploring. It's
+likely a loader for relevant maps, handles dispatch of events relevant to other
+systems, understands any necessary work to convey Devin's state between level
+scenes, etc.
+
+Likely a manager in its own right and an abstraction of a lot of logic.
+
+In a fixed-camera setup we may define boundaries here; in an openworld scenario we
+probably have signal handlers to load/unload scenes here.
+
+#### Player
+
+Player representation in a scene. Handles input intended to guide player actions
+(move, interact, use item, etc). Signals can be used to indicate state changes.
+
+Plausibly this exists as a peer node to specific map segments under a LevelManager
+to avoid needing to juggle the node as we move between map segments.
+
+##### Lamp
+
+Currently the only known player-attached item. Currently has visual representation
+but may not always.
+
+##### &lt;OtherItems&gt;
+
+TBD, do we have things that get player-attached? idk.
+
+#### LevelSegment
+
+An explorable segment of the world. Extremely ambigious on details, TBD.
+
+##### Placeables
+
+NPCs, objects, buildings. Things that Devin interacts with. We probably
+won't have a Node of type Placeable or even one that inherits from
+Placeable. Instead this is representative of a class of Nodes that will
+likely exist.
+
+Probably.

--- a/docs/tgo-audio.md
+++ b/docs/tgo-audio.md
@@ -1,0 +1,19 @@
+# TGO Gameplan for Audio Engineering
+
+## Current plan:
+
+1. Start rolling our own in an AudioManager to handle background music
+2. Learn/integrate some middleware (Wwise? fmod?)
+3. Swap to that
+
+## Middleware
+
+Current most likely contender is the this [wwise-godot-integration][addon-repo] addon.
+The authors demo it [here][addon-demo] in a talk to GodotCon 2021.
+
+A short video of about the kinds of work that motivates Audio middleware is available [here][adaptive-audio].
+
+
+[addon-repo]: https://github.com/alessandrofama/wwise-godot-integration
+[addon-demo]: https://www.youtube.com/watch?v=AX4vwsKxcDk
+[adaptive-audio]: https://www.youtube.com/watch?v=p-FLWabby4Y

--- a/docs/tgo-dialogic.md
+++ b/docs/tgo-dialogic.md
@@ -1,0 +1,107 @@
+# Dialogic2
+
+- [Dialogic2](#dialogic2)
+  - [Demo code](#demo-code)
+  - [Q\&A](#qa)
+    - [1. How to structure dialogue](#1-how-to-structure-dialogue)
+    - [2. Triggering conversations](#2-triggering-conversations)
+    - [3. Interacting with state](#3-interacting-with-state)
+    - [4. How to test](#4-how-to-test)
+    - [5. Custom UI](#5-custom-ui)
+      - [TODO](#todo)
+    - [6. Input: Masking Input](#6-input-masking-input)
+    - [7. Input: Choices](#7-input-choices)
+      - [TODO](#todo-1)
+    - [8. Translation](#8-translation)
+      - [TODO](#todo-2)
+    - [9. Engine-External Dialogue?](#9-engine-external-dialogue)
+      - [TODO](#todo-3)
+
+
+The following are the results of an initial survey into Dialogic 2.
+
+## Demo code
+We have a test project that does some basic experimentation with Dialogic 2 here:
+https://github.com/Small-Loan-Studio/dl2-demo
+
+## Q&A
+
+### 1. How to structure dialogue
+> We need an opinion for how to structure dialogue -- Dialogic2 uses a thing
+> called timelines to represent the flow of a conversation. do we write one
+> timeline per conversation, one per character, one per character/per act
+
+We should use one timeline per conversation.
+
+**Follow ups**:  
+How does that work in a situation where we have one NPC that has different
+“phases” of dialogue during a quest? Presumably we don't want to have to
+track which timeline to launch from non-dialogue code?
+
+### 2. Triggering conversations
+> How do we trigger conversations from code?
+
+- To launch a new conversation: `Dialogic.start(’conversation’)`
+- To check for active conversations: `if Dialogic.current_timeline != null:`
+
+### 3. Interacting with state
+> How do we specify the variables / functions available to be used in conversation?
+> Is there any kind of syntax checking (e.g. if we have a signal to emit/function
+> to call/variable to check during a conversation how many times will a typo fuck
+> us over)
+
+Dialogic has a variable system in place. `Set Variable` allows us to change this from
+within Dialogic timelines. [`Signal`][signal-link] allows us to exfiltrate state from within the
+conversation
+
+`Dialogic.VAR.<variable_name>` also allows outside code to access timeline state.
+Documentation [here][dot-var-link]
+
+There doesn't seem to be autocompletion or syntax checking. We could be missing it, but
+will make variable, function, signal typos will be difficult to catch automatically.
+
+[signal-link]: https://docs.dialogic.pro/dialogic-signals.html#1-signal-event
+[dot-var-link]: https://docs.dialogic.pro/variables.html
+
+### 4. How to test
+> When making changes to a timeline what's the best way to test those changes?
+> Can we construct a custom scene that makes it easy to set variables that are
+> needed to get to a specific point in time
+>
+> Do we have to start at the top or can we kick that test scene / conversation
+> off wherever we want
+
+Specific timelines can be tested with Play Timeline, which runs the current
+timeline. No obvious out-of-the-box ways to identify necessary variables to
+set but doing it manually in shouldn't be too bad. It can be done in the
+timeline directly or edited in the variables tab.
+
+> if the narrative team is the one testing can we make it simple for our
+> non-technical folks
+
+It's likely we'll want to build some test infrastructure for narrative here.
+
+### 5. Custom UI
+> How does UI customization work for Dialogic? Can we do speech bubbles?
+
+#### TODO
+
+### 6. Input: Masking Input
+> Does Dialogic keep our character from walking around randomly when in conversation?
+
+There does not seem to be any input masking with the default UI.
+    
+### 7. Input: Choices 
+> Do we get keyboard/controller and mouse interaction by default?
+#### TODO
+
+### 8. Translation
+> Is there a translation story / how is that handled?
+#### TODO
+
+### 9. Engine-External Dialogue?
+> can we export conversations and make it so that we can edit them then load at
+> runtime? The goal would be to enable narrative team to make changes without
+> rebuilding the whole game
+
+#### TODO

--- a/docs/tgo-levels.md
+++ b/docs/tgo-levels.md
@@ -1,0 +1,50 @@
+# Levels / Placeables
+
+- [Levels / Placeables](#levels--placeables)
+  - [Changelog](#changelog)
+  - [Presentation Style](#presentation-style)
+    - [An argument against premature optimization](#an-argument-against-premature-optimization)
+  - [Art style](#art-style)
+    - [Workflow](#workflow)
+    - [Our role](#our-role)
+  - [Open Questions](#open-questions)
+
+
+## Changelog
+- 2024-07-14: Capture initial braindump from Luke's research. Still a lot of amibuity.
+
+## Presentation Style
+
+From talking with Mario, I think we're going to be okay having the game broken up into relatively small areas, with doorways or portals to move between them.
+
+The camera can follow the player as they move around the space, and we should be able to load the whole space up at the same time. So we don't have to worry too much about streaming in the level (which we might if we had a large, open world).
+
+### An argument against premature optimization
+
+In theory we could do optimizations like loading in adjacent 'rooms' so that we are ready when the player goes through a door, but I would recommend against that kind of early optimization and say we should just try to dumbest way possible and only complicate if we find that we actually have performance issues.
+
+I think a good reference here is probably old 2D pokemon games. Which of course still have open areas, but break things up into towns, routes, floors of buildings, caves, and other areas which are always connected by some kind of portal/door.
+
+## Art style
+And then I talked with the art folks about workflow, and tried to pin down some basic answers about art direction where it might relate to us. Results are:
+
+1. we still don't know the exact size we are going to be working at. We do want charcters that are on the larger side when it comes to pixel art overword sprites (maybe something like 32 px tall). So that gives us some idea how big our overall canvas might be, but not enough to really make any firm decisions about it
+2. Art team does want to use tilemaps, instead of working with like a single large image. This has some implications for how we want to greybox, since it's probably better if we also greybox using tilemaps (i.e. make a fake tileset with just some basic colors, tiles with colliders, that kind of thing). One thing that I'm realizing now that I should have asked about is layers. I assume we will want to have multiple layers on the tilemap (i.e. we can place a shrub tile with transparency over a grass tile or over a dirt tile) but it would probably be nice to have an idea of how many layers we actually want to have so that we can set it up
+
+### Workflow
+
+When it comes to workflow, it seems like the artists want to be responsible for concept art and making the tileset, but not actually placing tiles in engine (which would be the job of level designers). My understanding of the basic flow here for a region would be. 
+
+1. designers decide generally what a place is and what it should have (i.e. "we need a house interior for x family that has a spooky dining room for this scene in the game")
+2. artists would make concept art for the location, probably pretty specific concept art including things like general layout, would go back and forth with designers to finilize
+3. aritsts would make/add to tilesets to support all the in game locations
+4. level designers would use those tileset and the concept art layouts to impliment the actual area in engine
+
+### Our role
+I'm imagining basically that leaving us with the task of importing the tileset into the engine and making them usable (including probably setting up collision), but not actually doing layout stuff ourselves.
+
+For more interesting interactions (say, a chest you can walk up to and interact with to get items from) I'm imagining we will treat those as separate from the tileset/map, and just make individual Scenes with sprites attached that level designers can drop into the world.
+
+## Open Questions
+1. How many and what layers does design/art expect to od
+2. How do we expect lighting these levels & layers to work

--- a/docs/tgo-save-load.md
+++ b/docs/tgo-save-load.md
@@ -1,0 +1,3 @@
+# Game State Persistance: Save & Load
+
+TODO


### PR DESCRIPTION
 Since this PR is all markdown and all new the easiest way to review it is probably just to read the branch: https://github.com/Small-Loan-Studio/TGO/blob/envy-dev-guide/README.md

Adds / updates several files:

    README.md — discusses the conventions we'll use around committing to the repo, release strategy, and code review regime.
    ./docs/tgo-arch.md — Somewhat raw thoughts around how we might structure the scene tree for the game. This will have far-reaching impact on dataflow / signal management so expect it to be best-effort and extremely open to feedback
    ./docs/tgo-dialogic.md — captures the results of an initial experiment that Lent did, we still have some questions to answer but we know a lot more now about how it might fit in
    ./docs/tgo-audio.md — largely a stub for a plan to deal with audio. We still need to flesh this out similarly to the Dialogic doc
    ./docs/tgo-save-load.md — completely a stub. I have a rough idea of how this might work but don't want to pollute the space if other folks have given it more thought (also it's not super pressing yet so saving spoons a bit)
    ./docs/tgo-levels.md — huge open question -- will be largely informed by Luke's conversations with Design/Art and the results of any experimentation he's been doing.

The most baked stuff here is the core README.md which lays out non-technical / primarily social decisions around the project.

After that is the overall architecture but that really should be a starting point for conversation. Would love to get pushback/feedback on the bits you've been thinking about and how it does/does not make sense based on what you've experienced thus far.

The systems-specific stuff is mostly just research dumps instead of attempts at technical direction.