### PR TITLE
[minor] Unset the Driver's autoload scene

### DIFF
--- a/Scenes/Driver.tscn
+++ b/Scenes/Driver.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=9 format=3 uid="uid://cobsc7v0oqc8l"]
+[gd_scene load_steps=8 format=3 uid="uid://cobsc7v0oqc8l"]
 
 [ext_resource type="Script" path="res://Scripts/Driver.gd" id="1_agcjs"]
 [ext_resource type="Script" path="res://Scripts/AudioManager.gd" id="2_4seev"]
 [ext_resource type="Script" path="res://Scripts/UI/Curtain.gd" id="2_gom2g"]
-[ext_resource type="PackedScene" uid="uid://d4mrsiv1l8m35" path="res://ZZ_Scratch/GreyboxingTools/BadLevelA.tscn" id="2_w5d7q"]
 [ext_resource type="Script" path="res://Scripts/Menu/MenuManager.gd" id="3_h1ccd"]
 [ext_resource type="PackedScene" uid="uid://ci7ksomi5hsr5" path="res://Scenes/Menu/DebugMenu.tscn" id="3_i7nbg"]
 [ext_resource type="Script" path="res://Scripts/UI/HUD.gd" id="4_kq6n3"]
@@ -11,7 +10,6 @@
 
 [node name="Driver" type="Node2D"]
 script = ExtResource("1_agcjs")
-autoload_scene = ExtResource("2_w5d7q")
 
 [node name="AudioManager" type="Node" parent="."]
 script = ExtResource("2_4seev")


### PR DESCRIPTION
Minor change that unsets the autoload scene in Driver. Never intended to merge this one, slipped in in the pushable boxes change.