### PR TITLE
Modifies torch behavior to work as @tool and adds placement helper (#…

### DIFF
--- a/Scenes/Components/LevelBase.tscn
+++ b/Scenes/Components/LevelBase.tscn
@@ -36,10 +36,18 @@ layer_0/z_index = 10
 [node name="Objects" type="Node2D" parent="."]
 y_sort_enabled = true
 
-[node name="Switches" type="Node" parent="Objects"]
+[node name="Switches" type="Node2D" parent="Objects"]
+y_sort_enabled = true
 
-[node name="Characters" type="Node" parent="Objects"]
+[node name="Characters" type="Node2D" parent="Objects"]
+y_sort_enabled = true
 
-[node name="Items" type="Node" parent="Objects"]
+[node name="Items" type="Node2D" parent="Objects"]
+y_sort_enabled = true
+
+[node name="Lighting" type="Node2D" parent="Objects"]
+y_sort_enabled = true
 
 [node name="Markers" type="Node" parent="."]
+
+[node name="CanvasModulate" type="CanvasModulate" parent="."]

--- a/Scenes/Components/Torch.tscn
+++ b/Scenes/Components/Torch.tscn
@@ -3,25 +3,32 @@
 [ext_resource type="Script" path="res://Scripts/Components/Greyboxing/Torch.gd" id="1_fjyou"]
 [ext_resource type="Texture2D" uid="uid://boyaede1duwf4" path="res://Art/Stub/stub_torch.png" id="2_lum1k"]
 
-[sub_resource type="Gradient" id="Gradient_ytk2o"]
+[sub_resource type="Gradient" id="Gradient_pdbb4"]
+offsets = PackedFloat32Array(0, 0.820669)
 colors = PackedColorArray(1, 1, 1, 1, 0, 0, 0, 1)
 
-[sub_resource type="GradientTexture2D" id="GradientTexture2D_lcdt0"]
-gradient = SubResource("Gradient_ytk2o")
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_bmn7b"]
+gradient = SubResource("Gradient_pdbb4")
+width = 32
+height = 32
 fill = 1
 fill_from = Vector2(0.5, 0.5)
-fill_to = Vector2(0.793578, 0.284404)
 
 [node name="Torch" type="Node2D"]
 script = ExtResource("1_fjyou")
+light_texture = SubResource("GradientTexture2D_bmn7b")
+display_height = null
+sprite_texture = ExtResource("2_lum1k")
 
 [node name="PointLight2D" type="PointLight2D" parent="."]
 position = Vector2(-2.38419e-07, -5)
-scale = Vector2(10, 10)
-texture = SubResource("GradientTexture2D_lcdt0")
-texture_scale = 0.75
+texture = SubResource("GradientTexture2D_bmn7b")
+offset = Vector2(0, -16)
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-texture = ExtResource("2_lum1k")
+visible = false
+offset = Vector2(0, -16)
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+visible = false
+offset = Vector2(0, -16)

--- a/Scenes/Driver.tscn
+++ b/Scenes/Driver.tscn
@@ -14,7 +14,7 @@
 [ext_resource type="PackedScene" uid="uid://dmyrmmjngi1ts" path="res://Scenes/UI/Debug/debug_day_night.tscn" id="10_8xh8g"]
 [ext_resource type="PackedScene" uid="uid://dyuykg87w5vff" path="res://Scenes/UI/Debug/devin_light_control.tscn" id="11_igd87"]
 [ext_resource type="PackedScene" uid="uid://cqin6fb282fjf" path="res://Scenes/Components/DayNightCycle.tscn" id="12_8kqo6"]
-[ext_resource type="PackedScene" uid="uid://b13wrl3bedjku" path="res://Scenes/Components/Greyboxing/Torch.tscn" id="13_kgcxt"]
+[ext_resource type="PackedScene" uid="uid://b13wrl3bedjku" path="res://Scenes/Components/Torch.tscn" id="13_kgcxt"]
 
 [node name="Driver" type="Node2D"]
 script = ExtResource("1_agcjs")
@@ -164,6 +164,8 @@ position = Vector2(0, 0)
 [node name="Camera2D" type="Camera2D" parent="GameWorld/Devin"]
 
 [node name="Debug_Torch" parent="GameWorld/Devin" instance=ExtResource("13_kgcxt")]
+light_size = 4.0
+display_height = 0
 
 [connection signal="request_load" from="OverlayManager/MenuManager/DebugMenu" to="." method="request_debug_load"]
 [connection signal="pressed" from="OverlayManager/HUD/DebugButton" to="." method="_on_debug_pressed"]

--- a/Scripts/Components/Greyboxing/Torch.gd
+++ b/Scripts/Components/Greyboxing/Torch.gd
@@ -1,58 +1,103 @@
 @tool
-
 class_name Torch
 extends Node2D
 
 @export_category("Lighting")
 @export var light_color: Color = Color.WHITE:
-	get:
-		return light_color
 	set(value):
 		light_color = value
-		_change_light_color(light_color)
+		_sync_light()
+
 @export var light_energy: float = 1.0:
-	get:
-		return light_energy
 	set(value):
 		light_energy = value
-		_change_light_energy(light_energy)
-@export var light_size: float = 0.75:
-	get:
-		return light_size
+		_sync_light()
+
+@export var light_size: float = 1:
 	set(value):
 		light_size = value
-		_change_light_size(light_size)
+		_sync_light()
+
 @export var light_texture: Texture2D = null:
-	get:
-		return light_texture
 	set(value):
 		light_texture = value
-		_change_light_texture(light_texture)
+		_sync_light()
 
-@export_category("Sprite")
-@export var sprite_texture: Texture = null:
-	get:
-		return sprite_texture
+@export_category("Visual")
+@export var display_height: int:
+	set(value):
+		display_height = value
+		_sync_height()
+
+@export_subgroup("Static Sprite")
+@export var sprite_texture: Texture2D = null:
 	set(value):
 		sprite_texture = value
-		_change_sprite_texture(sprite_texture)
+		_sync_visuals()
+
 @export_subgroup("Animated Sprite")
 @export var sprite_frames: SpriteFrames = null:
-	get:
-		return sprite_frames
 	set(value):
 		sprite_frames = value
-		_change_sprite_frames(sprite_frames)
+		_sync_visuals()
+
 @export var speed_scale: float = 1:
-	get:
-		return speed_scale
 	set(value):
 		speed_scale = value
-		_change_speed_scale(speed_scale)
+		_sync_visuals()
 
-@onready var _point_light_2d: PointLight2D = $PointLight2D
-@onready var _sprite_2d: Sprite2D = $Sprite2D
-@onready var _animated_sprite: AnimatedSprite2D = $AnimatedSprite2D
+var _point_light_2d: PointLight2D
+var _sprite_2d: Sprite2D
+var _animated_sprite: AnimatedSprite2D
+
+
+func _ready() -> void:
+	# taking this approach because we need access as a @tool script and @onready
+	# doesn't run but _ready does
+	_point_light_2d = get_node("PointLight2D")
+	_sprite_2d = get_node("Sprite2D")
+	_animated_sprite = get_node("AnimatedSprite2D")
+	_sync_visuals()
+	_sync_light()
+
+
+func _sync_height() -> void:
+	var offset_vec := display_height_offset()
+	if _sprite_2d != null:
+		_sprite_2d.offset = offset_vec
+	if _animated_sprite != null:
+		_animated_sprite.offset = offset_vec
+	if _point_light_2d != null:
+		_point_light_2d.offset = offset_vec
+
+
+func _sync_light() -> void:
+	if _point_light_2d == null:
+		return
+
+	_point_light_2d.energy = light_energy
+	_point_light_2d.texture_scale = light_size * 2
+	_point_light_2d.color = light_color
+	_point_light_2d.texture = light_texture
+
+
+func _sync_visuals() -> void:
+	if sprite_texture != null && _sprite_2d != null:
+		_sprite_2d.texture = (sprite_texture as Texture2D)
+		_sprite_2d.show()
+
+	if sprite_frames != null && _animated_sprite != null:
+		_animated_sprite.sprite_frames = sprite_frames
+		_animated_sprite.speed_scale = speed_scale
+		_animated_sprite.show()
+		if _sprite_2d != null:
+			_sprite_2d.hide()
+
+	_sync_height()
+
+
+func display_height_offset() -> Vector2:
+	return Vector2(0, -1 * ((display_height * 32) - 16))
 
 
 func is_lit() -> bool:
@@ -61,38 +106,3 @@ func is_lit() -> bool:
 
 func toggle(on: bool) -> void:
 	_point_light_2d.enabled = on
-
-
-func _change_light_color(new_color: Color) -> void:
-	if _point_light_2d != null:
-		_point_light_2d.color = new_color
-
-
-func _change_light_energy(new_energy: float) -> void:
-	if _point_light_2d != null:
-		_point_light_2d.energy = new_energy
-
-
-func _change_light_size(new_size: float) -> void:
-	if _point_light_2d != null:
-		_point_light_2d.texture_scale = new_size
-
-
-func _change_light_texture(new_texture: Texture) -> void:
-	if _point_light_2d != null:
-		_point_light_2d.texture = new_texture
-
-
-func _change_sprite_texture(new_texture: Texture) -> void:
-	if _sprite_2d != null:
-		_sprite_2d.texture = new_texture
-
-
-func _change_sprite_frames(new_frames: SpriteFrames) -> void:
-	if _animated_sprite != null:
-		_animated_sprite.sprite_frames = new_frames
-
-
-func _change_speed_scale(new_scale: float) -> void:
-	if _animated_sprite != null:
-		_animated_sprite.speed_scale = new_scale

--- a/Scripts/Components/Interactable.gd
+++ b/Scripts/Components/Interactable.gd
@@ -44,7 +44,9 @@ var actions: Array[Effect]:
 		if len(actions) > 0:
 			action_map[default_verb] = actions
 		if action_map.has(default_verb):
-			return action_map[default_verb]
+			var arr_eff: Array[Effect] = []
+			arr_eff.assign(action_map[default_verb])
+			return arr_eff
 		return []
 	set(value):
 		if len(value) > 0:

--- a/Scripts/Components/LevelBase.gd
+++ b/Scripts/Components/LevelBase.gd
@@ -1,11 +1,44 @@
+@tool
 class_name LevelBase
 extends Node2D
 
 const DEFAULT_MARKER: String = "PlayerStart"
 
+## Set this to a color to get an overlay and rough simulation of how your
+## lighting will look in that setting
+@export var editor_overlay_color: Color = Color.DIM_GRAY:
+	get:
+		return editor_overlay_color
+	set(value):
+		editor_overlay_color = value
+		if Engine.is_editor_hint():
+			_canvas_modulate.color = value
+
+## When enabled the color overlay will be applied. When unset it will not.
+@export var apply_editor_overlay: bool = false:
+	get:
+		return apply_editor_overlay
+	set(value):
+		apply_editor_overlay = value
+		if Engine.is_editor_hint():
+			_canvas_modulate.visible = apply_editor_overlay
+
 var driver: Driver
 
+var _canvas_modulate: CanvasModulate = null:
+	get:
+		# done as a property getter because we can't use @onready as part of @tool
+		# script and I don't know a better pattern
+		return get_node("CanvasModulate")
+
 @onready var _marker_root := $Markers
+
+
+func _ready() -> void:
+	if !Engine.is_editor_hint():
+		var ref := _canvas_modulate
+		remove_child(ref)
+		ref.queue_free()
 
 
 func setup(driver_in: Driver) -> void:

--- a/ZZ_Scratch/GreyboxingTools/BadLevelA.gd
+++ b/ZZ_Scratch/GreyboxingTools/BadLevelA.gd
@@ -1,3 +1,4 @@
+@tool
 class_name BadLevelA
 extends LevelBase
 

--- a/ZZ_Scratch/GreyboxingTools/BadLevelA.tscn
+++ b/ZZ_Scratch/GreyboxingTools/BadLevelA.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=3 uid="uid://d4mrsiv1l8m35"]
+[gd_scene load_steps=25 format=3 uid="uid://d4mrsiv1l8m35"]
 
 [ext_resource type="PackedScene" uid="uid://dyq8mcdsutnsa" path="res://Scenes/Components/LevelBase.tscn" id="1_iejup"]
 [ext_resource type="Script" path="res://ZZ_Scratch/GreyboxingTools/BadLevelA.gd" id="2_22a2t"]
@@ -15,6 +15,7 @@
 [ext_resource type="Resource" path="res://ZZ_Scratch/DialogicValidation/test_timeline.dtl" id="12_lpexj"]
 [ext_resource type="PackedScene" uid="uid://rgvfsx60t2ap" path="res://Scenes/Components/Inventory/Item.tscn" id="13_1m8di"]
 [ext_resource type="Resource" uid="uid://b7w2axnxl0fkt" path="res://Scripts/Resources/Items/Key.tres" id="15_svqc7"]
+[ext_resource type="PackedScene" uid="uid://b13wrl3bedjku" path="res://Scenes/Components/Torch.tscn" id="16_p267s"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_ptcao"]
 atlas = ExtResource("3_uhn0b")
@@ -52,6 +53,7 @@ target_state = 1
 
 [node name="LevelBase" instance=ExtResource("1_iejup")]
 script = ExtResource("2_22a2t")
+editor_overlay_color = Color(0.122252, 0.122252, 0.122252, 1)
 
 [node name="TileMap" parent="." index="0"]
 tile_set = ExtResource("2_nrxue")
@@ -135,5 +137,29 @@ tint = Color(0.171875, 0.6875, 0.179932, 1)
 action_verb = 5
 effects = Array[Resource("res://Scripts/Resources/Effect.gd")]([SubResource("Resource_yp128")])
 
+[node name="Torch" parent="Objects/Lighting" index="0" instance=ExtResource("16_p267s")]
+position = Vector2(208, 153)
+light_size = 1.5
+display_height = 2
+
+[node name="Torch_2" parent="Objects/Lighting" index="1" instance=ExtResource("16_p267s")]
+position = Vector2(269, 154)
+light_size = 1.5
+display_height = 2
+
+[node name="Torch_3" parent="Objects/Lighting" index="2" instance=ExtResource("16_p267s")]
+position = Vector2(209, 287)
+light_size = 3.0
+display_height = 2
+
+[node name="Torch_4" parent="Objects/Lighting" index="3" instance=ExtResource("16_p267s")]
+position = Vector2(398, 288)
+light_size = 3.0
+display_height = 2
+
 [node name="PlayerStart" type="Node2D" parent="Markers" index="0"]
 position = Vector2(522, 183)
+
+[node name="CanvasModulate" parent="." index="4"]
+visible = false
+color = Color(0.122252, 0.122252, 0.122252, 1)

--- a/ZZ_Scratch/GreyboxingTools/BadLevelB.tscn
+++ b/ZZ_Scratch/GreyboxingTools/BadLevelB.tscn
@@ -1,10 +1,10 @@
 [gd_scene load_steps=11 format=3 uid="uid://c3pgmxm78klqy"]
 
 [ext_resource type="PackedScene" uid="uid://dyq8mcdsutnsa" path="res://Scenes/Components/LevelBase.tscn" id="1_qb1mu"]
-[ext_resource type="Script" path="res://ZZ_Scratch/GreyboxingTools/BadLevelA.gd" id="2_fvydm"]
 [ext_resource type="TileSet" uid="uid://c5vrjt6pkv26m" path="res://ZZ_Scratch/GreyboxingTools/test_tileset.tres" id="3_mn72j"]
 [ext_resource type="Texture2D" uid="uid://v8wedauptprb" path="res://ZZ_Scratch/GreyboxingTools/template_tileset.png" id="4_eh4ix"]
 [ext_resource type="PackedScene" uid="uid://c2040l84asu8j" path="res://Scenes/Components/Interactable.tscn" id="5_io1ts"]
+[ext_resource type="PackedScene" uid="uid://b13wrl3bedjku" path="res://Scenes/Components/Torch.tscn" id="7_lqosr"]
 [ext_resource type="Script" path="res://Scripts/Resources/Effects/LevelLoadEffect.gd" id="7_pejyo"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_72abb"]
@@ -23,7 +23,6 @@ atlas = ExtResource("4_eh4ix")
 region = Rect2(64, 200, 59, 56)
 
 [node name="LevelBase" instance=ExtResource("1_qb1mu")]
-script = ExtResource("2_fvydm")
 
 [node name="TileMap" parent="." index="0"]
 tile_set = ExtResource("3_mn72j")
@@ -59,5 +58,13 @@ shape = SubResource("RectangleShape2D_lwweu")
 y_sort_enabled = true
 texture = SubResource("AtlasTexture_ptcao")
 
+[node name="Torch" parent="Objects/Lighting" index="0" instance=ExtResource("7_lqosr")]
+position = Vector2(85.312, 193.254)
+light_size = 6.0
+display_height = 0
+
 [node name="PlayerStart" type="Node2D" parent="Markers" index="0"]
 position = Vector2(490, 207)
+
+[node name="CanvasModulate" parent="." index="4"]
+color = Color(0.411765, 0.411765, 0.411765, 1)

--- a/addons_tgo/greyboxing/UI/ObjectHelperTorchDetails.gd
+++ b/addons_tgo/greyboxing/UI/ObjectHelperTorchDetails.gd
@@ -1,0 +1,46 @@
+@tool
+class_name ObjectsHelperTorchDetails
+extends VBoxContainer
+
+const TORCH_SCENE = preload("res://Scenes/Components/Torch.tscn")
+const DEFAULT_TEX = preload("res://Art/Stub/stub_torch.png")
+
+@onready var _radius_spinner: SpinBox = %Radius
+@onready var _sprite_check: CheckBox = %HasSprite
+@onready var _height_spinner: SpinBox = %Height
+@onready var _color_btn: ColorPickerButton = %Color
+@onready var _energy_bar: HSlider = %Energy
+
+
+func _on_has_sprite_toggled(toggled_on: bool) -> void:
+	_height_spinner.editable = toggled_on
+
+
+func has_display() -> bool:
+	return _sprite_check.toggle_mode
+
+
+func build() -> Torch:
+	var scn: Torch = TORCH_SCENE.instantiate()
+	scn._point_light_2d = scn.get_node("PointLight2D")
+	scn._sprite_2d = scn.get_node("Sprite2D")
+	scn._animated_sprite = scn.get_node("AnimatedSprite2D")
+	scn.light_color = _color_btn.color
+	scn.light_energy = _energy_bar.value
+
+	if !has_display():
+		scn.sprite_texture = null
+		scn.sprite_frames = null
+	else:
+		scn.sprite_texture = DEFAULT_TEX
+		scn.display_height = _height_spinner.value as int
+
+	scn.light_size = _radius_spinner.value
+
+	return scn
+
+
+func reset() -> void:
+	_radius_spinner.value = 1
+	_sprite_check.toggle_mode = true
+	_height_spinner.value = 0

--- a/addons_tgo/greyboxing/UI/ObjectHelperTorchDetails.tscn
+++ b/addons_tgo/greyboxing/UI/ObjectHelperTorchDetails.tscn
@@ -1,0 +1,107 @@
+[gd_scene load_steps=2 format=3 uid="uid://b82deie7daj5h"]
+
+[ext_resource type="Script" path="res://addons_tgo/greyboxing/UI/ObjectHelperTorchDetails.gd" id="1_hjg45"]
+
+[node name="ObjectHelperTorchDetails" type="VBoxContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_hjg45")
+
+[node name="ColorLine" type="HBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Label" type="Label" parent="ColorLine"]
+layout_mode = 2
+text = "Light Color"
+
+[node name="Color" type="ColorPickerButton" parent="ColorLine"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+color = Color(1, 1, 1, 1)
+
+[node name="EnergyLine" type="HBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Label" type="Label" parent="EnergyLine"]
+layout_mode = 2
+text = "Light Energy"
+
+[node name="Energy" type="HSlider" parent="EnergyLine"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+max_value = 3.0
+step = 0.1
+value = 0.7
+
+[node name="RadiusLine" type="HBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Label" type="Label" parent="RadiusLine"]
+layout_mode = 2
+text = "Light Radius
+"
+
+[node name="Radius" type="SpinBox" parent="RadiusLine"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 1.0
+max_value = 30.0
+step = 0.5
+value = 1.0
+suffix = "tiles"
+
+[node name="HasSpriteContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="HasSprite" type="CheckBox" parent="HasSpriteContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+button_pressed = true
+text = "Show Torch"
+
+[node name="MarginContainer" type="MarginContainer" parent="HasSpriteContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 16
+
+[node name="Label" type="Label" parent="HasSpriteContainer/MarginContainer"]
+layout_mode = 2
+text = "If set the light will have a sprite component showing the player where the light source is located."
+autowrap_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="HeightLine" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Label" type="Label" parent="VBoxContainer/HeightLine"]
+layout_mode = 2
+text = "Height"
+
+[node name="Height" type="SpinBox" parent="VBoxContainer/HeightLine"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+max_value = 10.0
+suffix = "tiles"
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 16
+
+[node name="Label" type="Label" parent="VBoxContainer/MarginContainer"]
+layout_mode = 2
+text = "When the torch has a visible component this determines how far above the ground it will be presented for y-sorting purposes."
+autowrap_mode = 2
+
+[connection signal="toggled" from="HasSpriteContainer/HasSprite" to="." method="_on_has_sprite_toggled"]

--- a/addons_tgo/greyboxing/UI/ObjectsHelper.gd
+++ b/addons_tgo/greyboxing/UI/ObjectsHelper.gd
@@ -12,6 +12,7 @@ const PUSHABLE_KEY = "pushable"
 const NPC_KEY = "npc"
 const ITEM_KEY = "item"
 const SWITCH_KEY = "switch"
+const TORCH_KEY = "torch"
 const CHARACTERS_CHILD_NODE = "Characters"
 const ITEMS_CHILD_NODE = "Items"
 const NPC_PATH = "res://Scripts/Resources/NPCs"
@@ -86,6 +87,9 @@ var _generic_block_movement: CheckBox = $Container/Scroll/AddItems/GenericDetail
 @onready var _switch := $Container/Scroll/AddItems/Switch
 @onready var _switch_detail: ObjectsHelperSwitchDetails = $Container/Scroll/AddItems/SwitchDetails
 
+@onready var _torch := $Container/Scroll/AddItems/Light
+@onready var _torch_detail: ObjectsHelperTorchDetails = $Container/Scroll/AddItems/LightDetails
+
 @onready var _complete_buttons := $Container/CompleteButtons
 @onready var _place_button := $Container/CompleteButtons/Place
 #gdlint: enable=max-line-length
@@ -98,6 +102,7 @@ func _ready() -> void:
 		NPC_KEY: [_npc, _npc_detail, _reset_npc_state],
 		ITEM_KEY: [_item, _item_detail, _reset_item_state],
 		SWITCH_KEY: [_switch, _switch_detail, _switch_detail.reset],
+		TORCH_KEY: [_torch, _torch_detail, _torch_detail.reset],
 	}
 	for k: String in _object_types.keys():
 		_valid_keys.append(k)
@@ -184,6 +189,8 @@ func _apply_implementation(obj_position: Vector2) -> void:
 			_apply_item(obj_position)
 		SWITCH_KEY:
 			_apply_switch(obj_position)
+		TORCH_KEY:
+			_apply_torch(obj_position)
 		_:
 			assert(false, "Invalid focused object Type: " + _focused_object_type)
 	var prev := _focused_object_type
@@ -291,6 +298,19 @@ func _apply_switch(obj_position: Vector2) -> void:
 	parent.add_child(obj)
 	obj.owner = _objects_parent.get_parent()
 	obj.global_position = obj_position
+
+
+func _apply_torch(obj_position: Vector2) -> void:
+	var parent := _objects_parent.get_node("Lighting")
+
+	var obj := _torch_detail.build()
+	obj.name = _mk_name_unique(parent, "Torch")
+
+	parent.add_child(obj)
+	obj.owner = _objects_parent.get_parent()
+
+	if _torch_detail.has_display():
+		obj.global_position = obj_position - obj.display_height_offset()
 
 
 func _reset_npc_state() -> void:

--- a/addons_tgo/greyboxing/UI/ObjectsHelper.tscn
+++ b/addons_tgo/greyboxing/UI/ObjectsHelper.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://1j701pum1cgx"]
+[gd_scene load_steps=6 format=3 uid="uid://1j701pum1cgx"]
 
 [ext_resource type="Script" path="res://addons_tgo/greyboxing/UI/ObjectsHelper.gd" id="1_u6ws1"]
 [ext_resource type="PackedScene" uid="uid://bvm1fjatmfabx" path="res://addons_tgo/greyboxing/UI/XbyY.tscn" id="2_grtm3"]
 [ext_resource type="PackedScene" uid="uid://efk1feabjm8y" path="res://addons_tgo/greyboxing/UI/ObjectsHelperSwitchDetails.tscn" id="2_wpheu"]
 [ext_resource type="Texture2D" uid="uid://3cvlh3bqqte5" path="res://Art/Items/Key.png" id="4_c3s30"]
+[ext_resource type="PackedScene" uid="uid://b82deie7daj5h" path="res://addons_tgo/greyboxing/UI/ObjectHelperTorchDetails.tscn" id="5_s0n33"]
 
 [node name="ObjectsHelper" type="Control"]
 layout_mode = 3
@@ -244,6 +245,15 @@ min_value = 1.0
 max_value = 1.0
 value = 1.0
 
+[node name="Light" type="Button" parent="Container/Scroll/AddItems"]
+layout_mode = 2
+text = "Light
+"
+
+[node name="LightDetails" parent="Container/Scroll/AddItems" instance=ExtResource("5_s0n33")]
+visible = false
+layout_mode = 2
+
 [node name="CompleteButtons" type="HBoxContainer" parent="Container"]
 visible = false
 layout_mode = 2
@@ -270,5 +280,6 @@ text = "Place"
 [connection signal="pressed" from="Container/Scroll/AddItems/Item" to="." method="_select_object_type" binds= ["item"]]
 [connection signal="visibility_changed" from="Container/Scroll/AddItems/ItemDetails" to="." method="_item_detail_visibility_changed"]
 [connection signal="item_selected" from="Container/Scroll/AddItems/ItemDetails/HBoxContainer/MarginContainer/ItemDropdown" to="." method="_item_dropdown_selected"]
+[connection signal="pressed" from="Container/Scroll/AddItems/Light" to="." method="_select_object_type" binds= ["torch"]]
 [connection signal="pressed" from="Container/CompleteButtons/Cancel" to="." method="_reset"]
 [connection signal="pressed" from="Container/CompleteButtons/Place" to="." method="_apply"]


### PR DESCRIPTION
…123)

Pretty much what it says on the box. The most interesting work is actually just the stuff I had to do to get Torch working as a `@tool` script since `@onready` vars don't get set in editor. I was also able to clean it up a lot by not re-creating the default property `get` call and collapsing all changes into a much smaller number of `_sync_<thing>` calls.

---------