### PR TITLE
[minor] Fix a tiny bug about switch placement

### DIFF
--- a/Scenes/Components/SimpleSwitch.tscn
+++ b/Scenes/Components/SimpleSwitch.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="PackedScene" uid="uid://bmwu7t5fqfmd5" path="res://Scenes/Components/Switch.tscn" id="1_a5k7c"]
 [ext_resource type="Script" path="res://Scripts/Components/SimpleSwitch.gd" id="2_xotxe"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_gtlpp"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_e1puu"]
 size = Vector2(0, 0)
 
 [node name="SimpleSwitch" instance=ExtResource("1_a5k7c")]
@@ -11,15 +11,16 @@ z_index = -1
 script = ExtResource("2_xotxe")
 track_variable = ""
 sensor_size = Vector2(0, 0)
-feedback_enabled = true
+feedback_enabled = false
 default_color = Color(0.745098, 0.745098, 0.745098, 1)
 active_color = Color(0, 0.392157, 0, 1)
 
 [node name="Polygon2D" type="Polygon2D" parent="." index="0"]
+visible = false
 color = Color(0.745098, 0.745098, 0.745098, 1)
 polygon = PackedVector2Array(0, 0, 0, 0, 0, 0, 0, 0)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." index="1"]
-shape = SubResource("RectangleShape2D_gtlpp")
+shape = SubResource("RectangleShape2D_e1puu")
 
 [connection signal="triggered" from="." to="." method="_on_triggered"]

--- a/addons_tgo/greyboxing/UI/ObjectsHelperSwitchDetails.gd
+++ b/addons_tgo/greyboxing/UI/ObjectsHelperSwitchDetails.gd
@@ -150,11 +150,11 @@ func build() -> Switch:
 		TMPL_SET_VAR:
 			assert(false, "Not implemented")
 
+	scn.sensor_size = Vector2(sensor_size_x.value, sensor_size_y.value)
 	scn.feedback_enabled = visible_checkbox.button_pressed
 	if visible_checkbox.button_pressed:
 		scn.default_color = default_color.color
 		scn.active_color = active_color.color
-		scn.sensor_size = Vector2(sensor_size_x.value, sensor_size_y.value)
 		scn.z_index = -1
 
 	return scn


### PR DESCRIPTION
Previously I was only setting the switch sensor sizing when visual feedback was set up. As a result if you didn't have a visual switch it wouldn't be triggerable (because it had no / a 0x0 sensor area).

Additionally I changed the SimpleSwitch scene to default to no visual feedback so that we didn't get any "for free" / by default when adding it to the scene.