### PR TITLE
Adds a debugging tool for quest states

### DIFF
--- a/Scenes/Driver.tscn
+++ b/Scenes/Driver.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://cobsc7v0oqc8l"]
+[gd_scene load_steps=18 format=3 uid="uid://cobsc7v0oqc8l"]
 
 [ext_resource type="Script" path="res://Scripts/Driver.gd" id="1_agcjs"]
 [ext_resource type="Script" path="res://Scripts/AudioManager.gd" id="2_4seev"]
@@ -13,6 +13,7 @@
 [ext_resource type="Script" path="res://Scripts/Components/Quests/QuestManager.gd" id="9_4hdkn"]
 [ext_resource type="PackedScene" uid="uid://dmyrmmjngi1ts" path="res://Scenes/UI/Debug/debug_day_night.tscn" id="10_8xh8g"]
 [ext_resource type="Script" path="res://Scripts/SerializationManager.gd" id="11_e6bsk"]
+[ext_resource type="PackedScene" uid="uid://my7v0l0el1dj" path="res://Scenes/UI/Debug/quest_debugger.tscn" id="11_g6nlc"]
 [ext_resource type="PackedScene" uid="uid://dyuykg87w5vff" path="res://Scenes/UI/Debug/devin_light_control.tscn" id="11_igd87"]
 [ext_resource type="PackedScene" uid="uid://cqin6fb282fjf" path="res://Scenes/Components/DayNightCycle.tscn" id="12_8kqo6"]
 [ext_resource type="PackedScene" uid="uid://b13wrl3bedjku" path="res://Scenes/Components/Torch.tscn" id="13_kgcxt"]
@@ -120,6 +121,9 @@ text = "Delete"
 layout_mode = 2
 
 [node name="DebugDayNight" parent="OverlayManager/HUD/DebugStack" instance=ExtResource("10_8xh8g")]
+layout_mode = 2
+
+[node name="QuestDebugger" parent="OverlayManager/HUD/DebugStack" instance=ExtResource("11_g6nlc")]
 layout_mode = 2
 
 [node name="Toast" type="ColorRect" parent="OverlayManager/HUD"]

--- a/Scenes/UI/Debug/quest_debugger.gd
+++ b/Scenes/UI/Debug/quest_debugger.gd
@@ -3,7 +3,6 @@ extends HBoxContainer
 
 var _mgr: QuestManager
 
-
 @onready var _status_group := $QuestStatus
 @onready var _quest_dropdown: OptionButton = $QuestOption
 @onready var _current_status: Label = $QuestStatus/CurrentQuestState

--- a/Scenes/UI/Debug/quest_debugger.gd
+++ b/Scenes/UI/Debug/quest_debugger.gd
@@ -1,0 +1,64 @@
+class_name QuestDebugger
+extends HBoxContainer
+
+var _mgr: QuestManager
+
+
+@onready var _status_group := $QuestStatus
+@onready var _quest_dropdown: OptionButton = $QuestOption
+@onready var _current_status: Label = $QuestStatus/CurrentQuestState
+@onready var _next_state: OptionButton = $QuestStatus/MarginContainer/HBoxContainer/NewQuestState
+
+
+func setup(quest_mgr: QuestManager) -> void:
+	_mgr = quest_mgr
+	_mgr.quest_updated.connect(_sync_quest)
+	var ids := _mgr.get_all_quest_ids()
+	ids.sort()
+
+	for id in ids:
+		_quest_dropdown.add_item(id)
+
+	for state: Enums.QuestState in Enums.QuestState.values():
+		_next_state.add_item(Enums.quest_state_name(state))
+
+
+func _get_selected_state() -> Enums.QuestState:
+	var cur_id := _next_state.get_selected_id()
+	var cur_txt := _next_state.get_item_text(cur_id)
+	return Enums.quest_state_from_str(cur_txt)
+
+
+func _get_selected_quest() -> String:
+	var cur_id := _quest_dropdown.get_selected_id()
+	return _quest_dropdown.get_item_text(cur_id)
+
+
+func _on_set_state_btn_pressed() -> void:
+	var cur_quest_id := _get_selected_quest()
+	if cur_quest_id == "":
+		return
+	var next_state := _get_selected_state()
+
+	var quest := _mgr.quest_by_id(cur_quest_id)
+	if quest.state == next_state:
+		return
+
+	quest.set_state(next_state)
+
+
+func _on_quest_option_item_selected(idx: int) -> void:
+	var quest_id := _quest_dropdown.get_item_text(idx)
+	if quest_id == "":
+		_status_group.hide()
+		return
+	_status_group.show()
+
+	var quest := _mgr.quest_by_id(quest_id)
+	_current_status.text = Enums.quest_state_name(quest.state)
+
+
+func _sync_quest(_quest_id: String) -> void:
+	# if the updated quest was selected this will refresh the active state;
+	# otherwise we don't really care
+	_on_quest_option_item_selected(_quest_dropdown.get_selected_id())

--- a/Scenes/UI/Debug/quest_debugger.tscn
+++ b/Scenes/UI/Debug/quest_debugger.tscn
@@ -1,0 +1,46 @@
+[gd_scene load_steps=2 format=3 uid="uid://my7v0l0el1dj"]
+
+[ext_resource type="Script" path="res://Scenes/UI/Debug/quest_debugger.gd" id="1_jo3ej"]
+
+[node name="QuestDebugger" type="HBoxContainer"]
+theme_override_constants/separation = 8
+script = ExtResource("1_jo3ej")
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 2
+text = "Quest"
+
+[node name="QuestOption" type="OptionButton" parent="."]
+layout_mode = 2
+focus_mode = 0
+item_count = 1
+selected = 0
+popup/item_0/text = ""
+popup/item_0/id = 0
+
+[node name="QuestStatus" type="HBoxContainer" parent="."]
+visible = false
+layout_mode = 2
+
+[node name="CurrentQuestState" type="Label" parent="QuestStatus"]
+layout_mode = 2
+text = "{state}"
+
+[node name="MarginContainer" type="MarginContainer" parent="QuestStatus"]
+layout_mode = 2
+theme_override_constants/margin_left = 8
+
+[node name="HBoxContainer" type="HBoxContainer" parent="QuestStatus/MarginContainer"]
+layout_mode = 2
+
+[node name="NewQuestState" type="OptionButton" parent="QuestStatus/MarginContainer/HBoxContainer"]
+layout_mode = 2
+focus_mode = 0
+
+[node name="SetStateBtn" type="Button" parent="QuestStatus/MarginContainer/HBoxContainer"]
+layout_mode = 2
+focus_mode = 0
+text = "Set State"
+
+[connection signal="item_selected" from="QuestOption" to="." method="_on_quest_option_item_selected"]
+[connection signal="pressed" from="QuestStatus/MarginContainer/HBoxContainer/SetStateBtn" to="." method="_on_set_state_btn_pressed"]

--- a/Scripts/Components/Quests/QuestManager.gd
+++ b/Scripts/Components/Quests/QuestManager.gd
@@ -186,7 +186,9 @@ func _on_quest_state_changed(
 	var canonicalized_id := quest_id.to_lower()
 	match new_state:
 		Enums.QuestState.DORMANT:
-			printerr("QuestState has changed to dormant, this is unexpected if not explicitly triggered.")
+			printerr(
+				"QuestState has changed to dormant, this is unexpected if not explicitly triggered."
+			)
 			_active_quests.erase(canonicalized_id)
 
 		Enums.QuestState.ACTIVE:

--- a/Scripts/Components/Quests/QuestManager.gd
+++ b/Scripts/Components/Quests/QuestManager.gd
@@ -38,6 +38,12 @@ func _connect_post_ready() -> void:
 	Driver.instance().inventory_mgr.inventory_updated.connect(_on_inventory_changed)
 
 
+func get_all_quest_ids() -> Array[String]:
+	var arr: Array[String] = []
+	arr.assign(_quest_dict.keys())
+	return arr
+
+
 ## saves a loaded set of quests to a target file; if the quests haven't been
 ## loaded prints an error and bails
 ##
@@ -179,6 +185,10 @@ func _on_quest_state_changed(
 ) -> void:
 	var canonicalized_id := quest_id.to_lower()
 	match new_state:
+		Enums.QuestState.DORMANT:
+			printerr("QuestState has changed to dormant, this is unexpected if not explicitly triggered.")
+			_active_quests.erase(canonicalized_id)
+
 		Enums.QuestState.ACTIVE:
 			_add_active_quest(canonicalized_id)
 

--- a/Scripts/Driver.gd
+++ b/Scripts/Driver.gd
@@ -25,6 +25,7 @@ var _last_loaded_level: LevelBase = null
 @onready var _debug_ui_quest: QuestTracker = $OverlayManager/HUD/DebugQuestUI
 @onready var _debug_dnc: DebugDayNight = $OverlayManager/HUD/DebugStack/DebugDayNight
 @onready var _debug_light: DevinLightControl = $OverlayManager/HUD/DebugStack/DevinLightControl
+@onready var _debug_quests: QuestDebugger = $OverlayManager/HUD/DebugStack/QuestDebugger
 
 
 static func instance() -> Driver:
@@ -61,6 +62,7 @@ func _post_ready() -> void:
 	## wire up debug bullshit
 	_debug_ui_quest.setup(quest_mgr)
 	_debug_dnc.setup(_day_night_cycle)
+	_debug_quests.setup(quest_mgr)
 	# let's just ignore the get_node call. it's trash but beyond temporary
 	_debug_light.setup(player, player.get_node("Debug_Torch"))
 

--- a/Scripts/Resources/Quest.gd
+++ b/Scripts/Resources/Quest.gd
@@ -257,6 +257,7 @@ func set_state(new_state: Enums.QuestState) -> void:
 		state = new_state
 		state_change.emit(id, old_state, new_state)
 
+
 func _to_string() -> String:
 	var next_ids: Array = next.map(func(e: Quest) -> String: return e.id)
 	var parent_ids: Array = _parent.map(func(e: Quest) -> String: return e.id)

--- a/Scripts/Resources/Quest.gd
+++ b/Scripts/Resources/Quest.gd
@@ -139,7 +139,7 @@ func evaluate() -> bool:
 				Enums.QuestState.ACTIVE:
 					return false
 				Enums.QuestState.FAILED:
-					if !q.may_fail:
+					if !qp.may_fail:
 						return self.mark_failed()
 				Enums.QuestState.COMPLETED:
 					if !chain_completed(q):
@@ -231,6 +231,31 @@ func mark_completed() -> bool:
 	state_change.emit(id, old_state, state)
 	return true
 
+
+## Forces the quest into the desired; will use the normal mark_<state> path
+## but will also explicitly set the state and emit the state change signal
+## itself if normal guard rails prevented the change.
+##
+## Generally this shouldn't be called in the normal flow of gameplay and
+## should be used in utility code or similar.
+func set_state(new_state: Enums.QuestState) -> void:
+	var success := false
+	match new_state:
+		Enums.QuestState.DORMANT:
+			# there is no mark_dormant
+			pass
+		Enums.QuestState.ACTIVE:
+			success = mark_active()
+		Enums.QuestState.FAILED:
+			success = mark_failed()
+		Enums.QuestState.COMPLETED:
+			success = mark_completed()
+		_:
+			assert(false, "Unexpected quest state: " + Enums.quest_state_name(new_state))
+	if !success:
+		var old_state := state
+		state = new_state
+		state_change.emit(id, old_state, new_state)
 
 func _to_string() -> String:
 	var next_ids: Array = next.map(func(e: Quest) -> String: return e.id)


### PR DESCRIPTION
Allows you to force an arbitrary quest into a specific state {dormant, active, failed, completed}.

If moving from dormant|active -> completed this will also trigger the corresponding completion effects. In all cases we trigger a quest_updated signal with old -> new state info.