### PR TITLE
Adds warnings when a quest is dependant on an invalid variable

### DIFF
--- a/Scripts/Components/Quests/QuestManager.gd
+++ b/Scripts/Components/Quests/QuestManager.gd
@@ -23,6 +23,7 @@ var _quest_dict: Dictionary = {}
 # Map<String, null>
 var _active_quests: Dictionary = {}
 
+
 func _ready() -> void:
 	_load_quests()
 
@@ -294,8 +295,13 @@ func _validate_variable_refs() -> void:
 		for c_idx in len(q.conditions):
 			var c := q.conditions[c_idx]
 			if c is QuestConditionVariable:
-					if !Dialogic.VAR.has(c.variable):
-						printerr("Misconfigured quest (id: %s) has condition referencing invalid variable. Condition %d: '%s'" % [q.id, c_idx, c.variable])
+				if !Dialogic.VAR.has(c.variable):
+					printerr(
+						(
+							"Misconfigured quest (id: %s) has condition referencing invalid variable. Condition %d: '%s'"
+							% [q.id, c_idx, c.variable]
+						)
+					)
 
 
 func debug_print() -> void:

--- a/Scripts/Components/Quests/QuestManager.gd
+++ b/Scripts/Components/Quests/QuestManager.gd
@@ -295,7 +295,7 @@ func _validate_variable_refs() -> void:
 			var c := q.conditions[c_idx]
 			if c is QuestConditionVariable:
 					if !Dialogic.VAR.has(c.variable):
-						printerr("Misconfigured quest: %s has condition referencing invalid variable. Condition %d: '%s'" % [q.id, c_idx, c.variable])
+						printerr("Misconfigured quest (id: %s) has condition referencing invalid variable. Condition %d: '%s'" % [q.id, c_idx, c.variable])
 
 
 func debug_print() -> void:

--- a/Scripts/Components/Quests/QuestManager.gd
+++ b/Scripts/Components/Quests/QuestManager.gd
@@ -13,6 +13,8 @@ signal quest_updated(id: String)
 const QUEST_IDX = 0
 const PATH_IDX = 1
 
+var run_validation: bool = true
+
 # maps from quest id to the quest and resource path
 # Map<String, [Quest, path]>
 var _quest_dict: Dictionary = {}
@@ -21,7 +23,6 @@ var _quest_dict: Dictionary = {}
 # Map<String, null>
 var _active_quests: Dictionary = {}
 
-
 func _ready() -> void:
 	_load_quests()
 
@@ -29,6 +30,9 @@ func _ready() -> void:
 	# been set up. Could work around this via setup() call to explicitly inject
 	# dependencies if needed. That wolud be the more designed way to do this...
 	Callable(_connect_post_ready).call_deferred()
+
+	if run_validation:
+		_validate_variable_refs()
 
 
 ## Connect to external data sources, should be run via deferred call so that it
@@ -282,6 +286,16 @@ func _process_completed_quest(id: String) -> void:
 			var next_quest_phase := phase_parent.phases[idx]
 			if next_quest_phase.quest.state != Enums.QuestState.ACTIVE:
 				next_quest_phase.quest.mark_active()
+
+
+func _validate_variable_refs() -> void:
+	for quest_id: String in get_all_quest_ids():
+		var q := quest_by_id(quest_id)
+		for c_idx in len(q.conditions):
+			var c := q.conditions[c_idx]
+			if c is QuestConditionVariable:
+					if !Dialogic.VAR.has(c.variable):
+						printerr("Misconfigured quest: %s has condition referencing invalid variable. Condition %d: '%s'" % [q.id, c_idx, c.variable])
 
 
 func debug_print() -> void:

--- a/Scripts/Resources/Quests/00-Prologue/other-quest.tres
+++ b/Scripts/Resources/Quests/00-Prologue/other-quest.tres
@@ -1,7 +1,15 @@
-[gd_resource type="Resource" script_class="Quest" load_steps=3 format=3 uid="uid://bxdn0h0w2ebqk"]
+[gd_resource type="Resource" script_class="Quest" load_steps=5 format=3 uid="uid://bxdn0h0w2ebqk"]
 
 [ext_resource type="Script" path="res://Scripts/Resources/Quest.gd" id="1_hcm75"]
 [ext_resource type="Resource" uid="uid://df2nc62jm1bw1" path="res://Scripts/Resources/Quests/01-ActOne/quest.tres" id="1_o2lpw"]
+[ext_resource type="Script" path="res://Scripts/Resources/QuestConditionVariable.gd" id="1_w8ix7"]
+
+[sub_resource type="Resource" id="Resource_recap"]
+script = ExtResource("1_w8ix7")
+variable = "aoeuaoeua"
+check_type = 3
+target_value = "1234"
+invert_result = false
 
 [resource]
 script = ExtResource("1_hcm75")
@@ -10,7 +18,7 @@ title = ""
 description = ""
 manual_start = false
 state = 0
-conditions = Array[Resource("res://Scripts/Resources/QuestCondition.gd")]([])
+conditions = Array[Resource("res://Scripts/Resources/QuestCondition.gd")]([SubResource("Resource_recap")])
 phases = Array[Resource("res://Scripts/QuestPhase.gd")]([])
 next = Array[ExtResource("1_hcm75")]([ExtResource("1_o2lpw")])
 results = Array[Resource("res://Scripts/Resources/Effect.gd")]([])


### PR DESCRIPTION
No generalized quest configuration utility yet but this at least adds some validation when the quests are processed. Currently it will only check that variable conditions point to a real variable.

[closes #102]