### PR TITLE
Removed deprecated `actions` proxy into action_map for Interactables

### DIFF
--- a/Scenes/Levels/BadLevelA.tscn
+++ b/Scenes/Levels/BadLevelA.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=40 format=3 uid="uid://d4mrsiv1l8m35"]
+[gd_scene load_steps=39 format=3 uid="uid://d4mrsiv1l8m35"]
 
 [ext_resource type="PackedScene" uid="uid://dyq8mcdsutnsa" path="res://Scenes/Components/LevelBase.tscn" id="1_iejup"]
 [ext_resource type="Script" path="res://ZZ_Scratch/GreyboxingTools/BadLevelA.gd" id="2_22a2t"]
@@ -19,7 +19,6 @@
 [ext_resource type="Resource" uid="uid://b7w2axnxl0fkt" path="res://Scripts/Resources/Items/Key.tres" id="15_svqc7"]
 [ext_resource type="Script" path="res://Scripts/Resources/Effects/ConditionalEffect.gd" id="15_x1ixy"]
 [ext_resource type="PackedScene" uid="uid://b13wrl3bedjku" path="res://Scenes/Components/Torch.tscn" id="16_p267s"]
-[ext_resource type="Script" path="res://Scripts/Components/Greyboxing/GreyboxObject.gd" id="20_odwfd"]
 [ext_resource type="Texture2D" uid="uid://c0504hqd3q12y" path="res://ZZ_Scratch/MarioDemo/simple_tileset.png" id="21_li46b"]
 [ext_resource type="Script" path="res://Scripts/Components/Interactable.gd" id="22_s68f6"]
 
@@ -100,10 +99,10 @@ dest_path = NodePath("../../Markers/PlayerStart")
 atlas = ExtResource("21_li46b")
 region = Rect2(0, 0, 32, 32)
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_1su76"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_alxrd"]
 size = Vector2(32, 32)
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_stfmq"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_p2ldv"]
 size = Vector2(32, 32)
 
 [node name="LevelBase" instance=ExtResource("1_iejup")]
@@ -231,27 +230,22 @@ tint = Color(0.988281, 0.92591, 0.262512, 1)
 effects = Array[Resource("res://Scripts/Resources/Effect.gd")]([SubResource("Resource_1tsfc")])
 
 [node name="Automatic Interactable" parent="Objects" index="11" instance=ExtResource("7_ipcqk")]
-y_sort_enabled = true
 position = Vector2(-25.3339, 33.4692)
-script = ExtResource("20_odwfd")
 can_block_movement = true
 can_interact = true
 tint = Color(0.878906, 0.0789642, 0.0789642, 1)
 effects = Array[Resource("res://Scripts/Resources/Effect.gd")]([SubResource("Resource_ct8mu")])
-y_sort_width = 72
-metadata/_edit_group_ = true
 
 [node name="Display" parent="Objects/Automatic Interactable" index="0"]
 modulate = Color(0.878906, 0.0789642, 0.0789642, 1)
 texture = SubResource("AtlasTexture_a3en3")
-offset = Vector2(0, -16)
 
 [node name="Physics" parent="Objects/Automatic Interactable" index="1"]
 collision_mask = 0
 
 [node name="Shape" parent="Objects/Automatic Interactable/Physics" index="0"]
 position = Vector2(0, -16)
-shape = SubResource("RectangleShape2D_1su76")
+shape = SubResource("RectangleShape2D_alxrd")
 
 [node name="Interactable" parent="Objects/Automatic Interactable" index="2"]
 position = Vector2(0, -1)
@@ -259,11 +253,13 @@ collision_layer = 2
 collision_mask = 0
 script = ExtResource("22_s68f6")
 automatic = true
-actions = Array[Resource("res://Scripts/Resources/Effect.gd")]([])
+action_map = {
+0: Array[Resource("res://Scripts/Resources/Effect.gd")]([SubResource("Resource_ct8mu")])
+}
 
 [node name="Shape" parent="Objects/Automatic Interactable/Interactable" index="0"]
 position = Vector2(0, -16)
-shape = SubResource("RectangleShape2D_stfmq")
+shape = SubResource("RectangleShape2D_p2ldv")
 
 [node name="PlayerStart" type="Node2D" parent="Markers" index="0"]
 position = Vector2(522, 183)

--- a/Scripts/Components/Interactable.gd
+++ b/Scripts/Components/Interactable.gd
@@ -35,36 +35,12 @@ signal triggered(actor: Character)
 
 # TODO: add conditions
 
-## A set of actions to be taken when this interactable gets triggered. Will be
-## evaluated before the signal is emitted.
-##
-## USAGE OF THIS IS DEPRECATED
-var actions: Array[Effect]:
-	get:
-		if len(actions) > 0:
-			action_map[default_verb] = actions
-		if action_map.has(default_verb):
-			var arr_eff: Array[Effect] = []
-			arr_eff.assign(action_map[default_verb])
-			return arr_eff
-		return []
-	set(value):
-		if len(value) > 0:
-			action_map[default_verb] = value
-		printerr("Should not be setting actions")
-		print_stack()
-		actions = value
-
 ## Tracks the level that the action is taking place in
 var _cur_level: LevelBase
 
 
 func _ready() -> void:
 	_cur_level = Utils.get_level_parent(self)
-	if Engine.is_editor_hint():
-		if len(actions) > 0:
-			action_map[default_verb] = actions
-			actions = []
 
 
 func trigger(actor: Character, action: Enums.ActionVerb = default_verb) -> void:
@@ -104,17 +80,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 ## Overrides the properties that an interactable reports as available for edit.
 func _get_property_list() -> Array[Dictionary]:
-	# this should keep "actions" loading and persisting to a .tscn while hiding
-	# it from the inspector UI
-	var props: Array[Dictionary] = [
-		{
-			"name": "actions",
-			"type": TYPE_ARRAY,
-			"hint": PROPERTY_HINT_ARRAY_TYPE,
-			"hint_string": "24/17:Effect",
-			"usage": PROPERTY_USAGE_STORAGE,
-		}
-	]
+	var props: Array[Dictionary] = []
 
 	# Walk the set of actions that have entries in the action_map and generate
 	# synthetic properties for editing since the inspector-default editor for


### PR DESCRIPTION
When converting from single-action interactables to multi-action I left a proxy that would hopefully help automatically convert things from the old way to the new one.

That work is done for the most part and I'd like to get everything fully pulled out before folks start to really go to town on building out levels.