### PR TITLE
fix: catch the remaining incorrect uses of queue_state_change

### DIFF
--- a/Scripts/Components/CharacterControl/State.gd
+++ b/Scripts/Components/CharacterControl/State.gd
@@ -15,7 +15,7 @@ func _local_setup() -> void:
 	pass
 
 
-func enter(_ctx: Variant) -> void:
+func enter(_ctx: Variant, _change_state: Callable) -> void:
 	pass
 
 

--- a/Scripts/Components/CharacterControl/StateMachine.gd
+++ b/Scripts/Components/CharacterControl/StateMachine.gd
@@ -59,7 +59,7 @@ func _maybe_enter_state(depth: int = 0) -> void:
 		print("(%d) %s -> %s" % [depth, _cur_state.name, _next_state.name])
 	_cur_state = _next_state
 	_next_state = null
-	_cur_state.enter(_next_state_ctx)
+	_cur_state.enter(_next_state_ctx, queue_state_change)
 	# sometimes a state can immediately defer to a subsequent state;
 	# it's not elegant but eat that here
 	_maybe_enter_state(depth + 1)

--- a/Scripts/Components/CharacterControl/StateMachine.gd
+++ b/Scripts/Components/CharacterControl/StateMachine.gd
@@ -51,7 +51,9 @@ func _maybe_enter_state(depth: int = 0) -> void:
 	if depth > 4:
 		# Sometimes we make poor decisions in life like infinite state loops.
 		# Don't let them be the end, just face plant and move on.
-		printerr("StateMachine having a bad time enter state depth of %d. Aborting transitions" % [depth])
+		printerr(
+			"StateMachine having a bad time enter state depth of %d. Aborting transitions" % [depth]
+		)
 		return
 
 	_cur_state.exit()

--- a/Scripts/Components/CharacterControl/StateMachine.gd
+++ b/Scripts/Components/CharacterControl/StateMachine.gd
@@ -44,16 +44,25 @@ func setup(ctx: Variant = null) -> void:
 	_setup_complete = true
 
 
-func _maybe_enter_state() -> void:
+func _maybe_enter_state(depth: int = 0) -> void:
 	if _next_state == null:
+		return
+
+	if depth > 4:
+		# Sometimes we make poor decisions in life like infinite state loops.
+		# Don't let them be the end, just face plant and move on.
+		printerr("StateMachine having a bad time enter state depth of %d. Aborting transitions" % [depth])
 		return
 
 	_cur_state.exit()
 	if print_state_changes:
-		print("%s -> %s" % [_cur_state.name, _next_state.name])
+		print("(%d) %s -> %s" % [depth, _cur_state.name, _next_state.name])
 	_cur_state = _next_state
 	_next_state = null
 	_cur_state.enter(_next_state_ctx)
+	# sometimes a state can immediately defer to a subsequent state;
+	# it's not elegant but eat that here
+	_maybe_enter_state(depth + 1)
 
 
 func run_input(event: InputEvent) -> void:

--- a/Scripts/Components/CharacterControl/States/CharacterState.gd
+++ b/Scripts/Components/CharacterControl/States/CharacterState.gd
@@ -13,7 +13,7 @@ func _local_setup() -> void:
 	_animated_sprite = _ctx.character._sprite
 
 
-func maybe_interact() -> bool:
+func maybe_interact(change_state: Callable) -> bool:
 	var just_pressed := _ctx.controller.get_just_pressed()
 
 	if !_ctx.character.target.is_set():
@@ -21,24 +21,24 @@ func maybe_interact() -> bool:
 
 	if _ctx.character.target.get_interactable():
 		if _ctx.character.target.get_interactable().automatic:
-			_state_machine.queue_state_change(interact_state)
+			change_state.call(interact_state)
 			return true
 
 	if Enums.InputAction.INTERACT in just_pressed:
-		_state_machine.queue_state_change(interact_state)
+		change_state.call(interact_state)
 		return true
 
 	return false
 
 
-func maybe_menu() -> bool:
+func maybe_menu(change_state: Callable) -> bool:
 	var just_pressed := _ctx.controller.get_just_pressed()
 	if menu_state == null || !_ctx.controller.just_pressed(Enums.InputAction.MENU):
 		return false
 
 	(
-		_state_machine
-		. queue_state_change(
+		change_state
+		. call(
 			menu_state,
 			menu_state.mk_args(Enums.MenuType.GAMEPLAY),
 		)

--- a/Scripts/Components/CharacterControl/States/Idle.gd
+++ b/Scripts/Components/CharacterControl/States/Idle.gd
@@ -10,7 +10,7 @@ func _local_setup() -> void:
 	_animated_sprite = _ctx.character._sprite
 
 
-func enter(_ctx: Variant) -> void:
+func enter(_ctx: Variant, _change_state: Callable) -> void:
 	if _animation_name != "":
 		_animated_sprite.play(_animation_name)
 	else:

--- a/Scripts/Components/CharacterControl/States/Idle.gd
+++ b/Scripts/Components/CharacterControl/States/Idle.gd
@@ -17,8 +17,8 @@ func enter(_ctx: Variant) -> void:
 		_animated_sprite.stop()
 
 
-func run_input(_event: InputEvent, _change_state: Callable) -> void:
-	if maybe_menu() || maybe_interact():
+func run_input(_event: InputEvent, change_state: Callable) -> void:
+	if maybe_menu(change_state) || maybe_interact(change_state):
 		# this is a noop but here to quiet lint
 		return
 

--- a/Scripts/Components/CharacterControl/States/Interact.gd
+++ b/Scripts/Components/CharacterControl/States/Interact.gd
@@ -6,7 +6,7 @@ extends CharacterState
 var _tgt: CharacterTarget
 
 
-func enter(_enter_ctx: Variant) -> void:
+func enter(_enter_ctx: Variant, _change_state: Callable) -> void:
 	_tgt = _ctx.character.target
 
 	if _tgt.is_interactable():

--- a/Scripts/Components/CharacterControl/States/Menu.gd
+++ b/Scripts/Components/CharacterControl/States/Menu.gd
@@ -8,7 +8,7 @@ var _waiting := false
 var _done_waiting := false
 
 
-func enter(_ctx: Variant) -> void:
+func enter(_ctx: Variant, _change_state: Callable) -> void:
 	_menu_type = _ctx["menu"]
 	_waiting = false
 	_done_waiting = false

--- a/Scripts/Components/CharacterControl/States/PushPull.gd
+++ b/Scripts/Components/CharacterControl/States/PushPull.gd
@@ -21,7 +21,7 @@ var _impulse: Vector2
 var _projected_impulse: Vector2
 
 
-func enter(ctx: Variant) -> void:
+func enter(ctx: Variant, _change_state: Callable) -> void:
 	var ctx_dict := ctx as Dictionary
 	_push_direction = ctx_dict["push_direction"]
 	_movement_axis = Enums.direction_push_pull_axis(_push_direction)

--- a/Scripts/Components/CharacterControl/States/PushPull.gd
+++ b/Scripts/Components/CharacterControl/States/PushPull.gd
@@ -30,9 +30,9 @@ func enter(ctx: Variant) -> void:
 	_handle_animation()
 
 
-func run_input(_event: InputEvent, _change_state: Callable) -> void:
+func run_input(_event: InputEvent, change_state: Callable) -> void:
 	if Enums.InputAction.INTERACT in _ctx.controller.get_just_pressed():
-		_state_machine.queue_state_change(idle_state)
+		change_state.call(idle_state)
 		_hud.set_toast(Enums.action_verb_name(Enums.ActionVerb.PUSH_PULL))
 		return
 

--- a/Scripts/Components/CharacterControl/States/Sprint.gd
+++ b/Scripts/Components/CharacterControl/States/Sprint.gd
@@ -10,12 +10,12 @@ var _direction: Enums.Direction
 var _has_entered: bool
 
 
-func enter(_state: Variant) -> void:
+func enter(_state: Variant, change_state: Callable) -> void:
 	if _get_stam().value < stamina_drain_rate:
-		_state_machine.queue_state_change(idle_state)
+		change_state.call(idle_state)
 		return
 	_has_entered = true
-	run_input(null, _state_machine.queue_state_change)
+	run_input(null, change_state)
 
 
 func exit() -> void:

--- a/Scripts/Components/CharacterControl/States/Walk.gd
+++ b/Scripts/Components/CharacterControl/States/Walk.gd
@@ -36,7 +36,7 @@ func run_input(_event: InputEvent, change_state: Callable) -> void:
 	else:
 		change_state.call(idle_state)
 
-	maybe_interact()
+	maybe_interact(change_state)
 
 
 func run_physics(_delta: float, _change_state: Callable) -> void:

--- a/Scripts/Components/CharacterControl/States/Walk.gd
+++ b/Scripts/Components/CharacterControl/States/Walk.gd
@@ -9,8 +9,8 @@ var _direction: Enums.Direction
 var _has_entered: bool
 
 
-func enter(_state: Variant) -> void:
-	run_input(null, _state_machine.queue_state_change)
+func enter(_state: Variant, change_state: Callable) -> void:
+	run_input(null, change_state)
 	_has_entered = true
 
 


### PR DESCRIPTION
This should catch all remaning incorrect uses of `queue_state_change`. I think the usage is still a tad confusing due to the fact it is still used on enter and things like that, but maybe it can be revisited later.


Fixes #191