### PR TITLE
fix: use functions that work for image resources

### DIFF
--- a/Scenes/Components/interacting/interact_menu.gd
+++ b/Scenes/Components/interacting/interact_menu.gd
@@ -41,6 +41,6 @@ func _ready() -> void:
 		var option := InteractOptionScene.instantiate()
 		option.label = Enums.action_verb_name(action)
 		option.layout = layout
-		option.symbol = Enums.input_action_symbol(Enums.InputAction.INTERACT)
+		option.symbol = Enums.input_action_symbol_texture(Enums.InputAction.INTERACT)
 		_container.add_child(option)
 	self.add_child(_container)

--- a/Scenes/Components/interacting/interact_option.gd
+++ b/Scenes/Components/interacting/interact_option.gd
@@ -14,7 +14,7 @@ enum { LAYOUT_LEFT, LAYOUT_RIGHT }
 		if _rlabel:
 			_rlabel.text = _clabel
 @export var layout := LAYOUT_RIGHT
-@export var symbol: Image = null
+@export var symbol: CompressedTexture2D = null
 
 var _clabel: String = ""
 
@@ -66,7 +66,7 @@ func toggle_chevron() -> void:
 
 
 func _ready() -> void:
-	_symbol.texture = ImageTexture.create_from_image(symbol)
+	_symbol.texture = symbol
 	_symbol.get_parent().hide()
 	match layout:
 		LAYOUT_LEFT:

--- a/Scenes/Components/interacting/interact_panel.gd
+++ b/Scenes/Components/interacting/interact_panel.gd
@@ -147,12 +147,12 @@ func _get_label() -> String:
 			return ""
 
 
-func _get_symbol() -> Image:
+func _get_symbol() -> CompressedTexture2D:
 	match input:
 		Enums.InputAction.EXAMINE:
-			return Enums.input_action_symbol(input)
+			return Enums.input_action_symbol_texture(input)
 		Enums.InputAction.INTERACT:
-			return Enums.input_action_symbol(input)
+			return Enums.input_action_symbol_texture(input)
 		_:
 			assert(false, "ERROR: Unsupported input action selected.")
 			return null

--- a/Scenes/Driver.tscn
+++ b/Scenes/Driver.tscn
@@ -12,7 +12,7 @@
 [ext_resource type="PackedScene" uid="uid://dukcf64qxy46o" path="res://Scenes/UI/Debug/Inventory.tscn" id="7_3yw60"]
 [ext_resource type="PackedScene" uid="uid://dqrxejwlgxsgu" path="res://Scenes/UI/Debug/QuestTracker.tscn" id="8_8e3e0"]
 [ext_resource type="Script" path="res://Scripts/Components/Quests/QuestManager.gd" id="9_4hdkn"]
-[ext_resource type="PackedScene" uid="uid://c0kelgau5kji2" path="res://Scenes/UI/Debug/debug_equipment.tscn" id="9_n1ypf"]
+[ext_resource type="PackedScene" path="res://Scenes/UI/Debug/debug_equipment.tscn" id="9_n1ypf"]
 [ext_resource type="PackedScene" uid="uid://dmyrmmjngi1ts" path="res://Scenes/UI/Debug/debug_day_night.tscn" id="10_8xh8g"]
 [ext_resource type="Script" path="res://Scripts/SerializationManager.gd" id="11_e6bsk"]
 [ext_resource type="PackedScene" uid="uid://my7v0l0el1dj" path="res://Scenes/UI/Debug/quest_debugger.tscn" id="11_g6nlc"]

--- a/Scenes/Levels/BadLevelA.tscn
+++ b/Scenes/Levels/BadLevelA.tscn
@@ -100,10 +100,10 @@ dest_path = NodePath("../../Markers/PlayerStart")
 atlas = ExtResource("21_li46b")
 region = Rect2(0, 0, 32, 32)
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_now7l"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_7qfel"]
 size = Vector2(32, 32)
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_dnpv7"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_uy6hq"]
 size = Vector2(32, 32)
 
 [node name="LevelBase" instance=ExtResource("1_iejup")]
@@ -251,7 +251,7 @@ collision_mask = 0
 
 [node name="Shape" parent="Objects/Automatic Interactable/Physics" index="0"]
 position = Vector2(0, -16)
-shape = SubResource("RectangleShape2D_now7l")
+shape = SubResource("RectangleShape2D_7qfel")
 
 [node name="Interactable" parent="Objects/Automatic Interactable" index="2"]
 position = Vector2(0, -1)
@@ -265,7 +265,7 @@ action_map = {
 
 [node name="Shape" parent="Objects/Automatic Interactable/Interactable" index="0"]
 position = Vector2(0, -16)
-shape = SubResource("RectangleShape2D_dnpv7")
+shape = SubResource("RectangleShape2D_uy6hq")
 
 [node name="PlayerStart" type="Node2D" parent="Markers" index="0"]
 position = Vector2(522, 183)

--- a/Scripts/Enums.gd
+++ b/Scripts/Enums.gd
@@ -209,12 +209,12 @@ static func input_action_name(ia: InputAction) -> String:
 	return ""
 
 
-static func input_action_symbol(ia: InputAction) -> Image:
+static func input_action_symbol_texture(ia: InputAction) -> CompressedTexture2D:
 	match ia:
 		InputAction.EXAMINE:
-			return Image.load_from_file("res://Art/interacting/symbol_square.png")
+			return preload("res://Art/interacting/symbol_square.png")
 		InputAction.INTERACT:
-			return Image.load_from_file("res://Art/interacting/symbol_cross.png")
+			return preload("res://Art/interacting/symbol_cross.png")
 		_:
 			return null
 


### PR DESCRIPTION
No idea why Godot provides functions that won't work on export with minimal to no warning but they do and we need to not use them...


Fixes #200