### PR TITLE
KAS minor tweaks

### DIFF
--- a/Scenes/Driver.tscn
+++ b/Scenes/Driver.tscn
@@ -229,6 +229,12 @@ y_sort_enabled = true
 follow_viewport_enabled = true
 
 [node name="DayNightOverlay" parent="GameWorld" instance=ExtResource("12_8kqo6")]
+dawn_start_h = 5
+day_start_h = 7
+dusk_start_h = 15
+night_start_h = 17
+dusk_color = Color(0.548625, 0.5225, 0.55, 1)
+night_color = Color(0.027451, 0.0117647, 0.027451, 1)
 day_length_seconds = 900
 day_autostart = true
 
@@ -236,6 +242,8 @@ day_autostart = true
 unique_name_in_owner = true
 visible = false
 position = Vector2(0, 0)
+scale = Vector2(1.6, 1.6)
+safe_margin = 0.8
 
 [node name="Camera2D" type="Camera2D" parent="GameWorld/Devin"]
 zoom = Vector2(1.2, 1.2)

--- a/Scripts/Resources/GearSpec/simple_torch.gd
+++ b/Scripts/Resources/GearSpec/simple_torch.gd
@@ -21,7 +21,7 @@ static func add_torch(c: Character, color: Color) -> Torch:
 	c.add_child(torch_node)
 	# configure the torch
 	torch_node.light_color = color
-	torch_node.light_size = 3
+	torch_node.light_size = 2
 	torch_node.sprite_texture = null
 	torch_node.sprite_frames = null
 	torch_node.toggle(false)

--- a/Scripts/Resources/Items/Torch.tres
+++ b/Scripts/Resources/Items/Torch.tres
@@ -6,7 +6,7 @@
 
 [sub_resource type="Resource" id="Resource_3jmuo"]
 script = ExtResource("1_8vude")
-light_color = Color(1, 1, 1, 1)
+light_color = Color(1, 0.945098, 0.901961, 1)
 
 [resource]
 script = ExtResource("1_6glhw")


### PR DESCRIPTION
Changed Devin to 1.6-times scale. This feels right -- I'm happy to consider this "final pending approval/testing". 

Changed the colours of Dawn/Dusk and Night in the day/night cycle -- as well as the times to reflect typical sunrise/sunset in January in Northern England.

Reduced the radius of the torch and changed its colour to give it an orange tint. I tried, and failed, to create two additional Torch items with varying radii and colours. Would have been nice but alas not critical right now and more for exploration.