### PR TITLE
Some tweaks for audio and narrative

### DIFF
--- a/Scenes/Levels/Debug/BadLevelB.tscn
+++ b/Scenes/Levels/Debug/BadLevelB.tscn
@@ -11,9 +11,8 @@
 [ext_resource type="Resource" uid="uid://b7w2axnxl0fkt" path="res://Scripts/Resources/Items/Key.tres" id="9_ewmie"]
 [ext_resource type="PackedScene" uid="uid://bx2qjlw58ci20" path="res://Scenes/Components/Greyboxing/GreyboxObject.tscn" id="10_k3j1d"]
 [ext_resource type="PackedScene" uid="uid://bmkq7u7c66eru" path="res://Scenes/Components/signal_to_effect.tscn" id="10_lgusy"]
+[ext_resource type="Script" path="res://Scripts/Resources/Effects/ToggleDoorEffect.gd" id="11_6vl2n"]
 [ext_resource type="Script" path="res://Scripts/Resources/Effects/LevelLoadEffect.gd" id="11_cp71p"]
-[ext_resource type="Script" path="res://Scenes/Components/Inventory/Item.gd" id="11_fjqni"]
-[ext_resource type="Resource" uid="uid://bjjqkmtq6eybl" path="res://Scripts/Resources/Items/Satchel.tres" id="12_6gh4a"]
 [ext_resource type="PackedScene" uid="uid://bwlnxooxokiw6" path="res://Scenes/Components/door.tscn" id="12_rh8so"]
 [ext_resource type="Script" path="res://Scripts/Resources/Conditions/InventoryCheckCondition.gd" id="13_d5pwi"]
 [ext_resource type="Resource" uid="uid://cc5v3qeeoiet" path="res://Scripts/Resources/Conditions/Custom/DevinHasKey.tres" id="15_alexr"]
@@ -22,6 +21,11 @@
 [sub_resource type="Resource" id="Resource_ql4ne"]
 script = ExtResource("6_1o8fo")
 timeline = ExtResource("7_4h58g")
+
+[sub_resource type="Resource" id="Resource_fvb58"]
+script = ExtResource("11_6vl2n")
+door_id = "BadLevelB.auto_door"
+door_action = "open"
 
 [sub_resource type="Resource" id="Resource_bl5wy"]
 script = ExtResource("11_cp71p")
@@ -66,13 +70,7 @@ item = ExtResource("9_ewmie")
 quantity = 1
 
 [node name="PickedUp" parent="Objects/Items/QUEST_KEY" index="2" instance=ExtResource("10_lgusy")]
-
-[node name="SATCHEL" type="Node2D" parent="Objects/Items" index="1" instance=ExtResource("8_shpqy")]
-texture_filter = 1
-position = Vector2(88.0453, 73.7955)
-script = ExtResource("11_fjqni")
-item = ExtResource("12_6gh4a")
-quantity = 1
+effects = Array[Resource("res://Scripts/Resources/Effect.gd")]([SubResource("Resource_fvb58")])
 
 [node name="LevelTeleport" parent="Objects" index="3" instance=ExtResource("10_k3j1d")]
 position = Vector2(279, 364)

--- a/Scenes/Levels/Debug/BadLevelB.tscn
+++ b/Scenes/Levels/Debug/BadLevelB.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=3 uid="uid://c3pgmxm78klqy"]
+[gd_scene load_steps=22 format=3 uid="uid://c3pgmxm78klqy"]
 
 [ext_resource type="PackedScene" uid="uid://dyq8mcdsutnsa" path="res://Scenes/Components/LevelBase.tscn" id="1_t8b0a"]
 [ext_resource type="Script" path="res://ZZ_Scratch/GreyboxingTools/BadLevelA.gd" id="2_hodgd"]
@@ -11,9 +11,9 @@
 [ext_resource type="Resource" uid="uid://b7w2axnxl0fkt" path="res://Scripts/Resources/Items/Key.tres" id="9_ewmie"]
 [ext_resource type="PackedScene" uid="uid://bx2qjlw58ci20" path="res://Scenes/Components/Greyboxing/GreyboxObject.tscn" id="10_k3j1d"]
 [ext_resource type="PackedScene" uid="uid://bmkq7u7c66eru" path="res://Scenes/Components/signal_to_effect.tscn" id="10_lgusy"]
-[ext_resource type="Script" path="res://Scripts/Resources/Effects/ToggleDoorEffect.gd" id="11_6vl2n"]
 [ext_resource type="Script" path="res://Scripts/Resources/Effects/LevelLoadEffect.gd" id="11_cp71p"]
-[ext_resource type="Script" path="res://Scripts/Resources/Effects/DebugEffect.gd" id="12_admpp"]
+[ext_resource type="Script" path="res://Scenes/Components/Inventory/Item.gd" id="11_fjqni"]
+[ext_resource type="Resource" uid="uid://bjjqkmtq6eybl" path="res://Scripts/Resources/Items/Satchel.tres" id="12_6gh4a"]
 [ext_resource type="PackedScene" uid="uid://bwlnxooxokiw6" path="res://Scenes/Components/door.tscn" id="12_rh8so"]
 [ext_resource type="Script" path="res://Scripts/Resources/Conditions/InventoryCheckCondition.gd" id="13_d5pwi"]
 [ext_resource type="Resource" uid="uid://cc5v3qeeoiet" path="res://Scripts/Resources/Conditions/Custom/DevinHasKey.tres" id="15_alexr"]
@@ -22,15 +22,6 @@
 [sub_resource type="Resource" id="Resource_ql4ne"]
 script = ExtResource("6_1o8fo")
 timeline = ExtResource("7_4h58g")
-
-[sub_resource type="Resource" id="Resource_u8kb4"]
-script = ExtResource("11_6vl2n")
-door_id = "BadLevelB.auto_door"
-door_action = "open"
-
-[sub_resource type="Resource" id="Resource_2837c"]
-script = ExtResource("12_admpp")
-message = "QUEST_KEY picked up"
 
 [sub_resource type="Resource" id="Resource_bl5wy"]
 script = ExtResource("11_cp71p")
@@ -75,7 +66,13 @@ item = ExtResource("9_ewmie")
 quantity = 1
 
 [node name="PickedUp" parent="Objects/Items/QUEST_KEY" index="2" instance=ExtResource("10_lgusy")]
-effects = Array[Resource("res://Scripts/Resources/Effect.gd")]([SubResource("Resource_u8kb4"), SubResource("Resource_2837c")])
+
+[node name="SATCHEL" type="Node2D" parent="Objects/Items" index="1" instance=ExtResource("8_shpqy")]
+texture_filter = 1
+position = Vector2(88.0453, 73.7955)
+script = ExtResource("11_fjqni")
+item = ExtResource("12_6gh4a")
+quantity = 1
 
 [node name="LevelTeleport" parent="Objects" index="3" instance=ExtResource("10_k3j1d")]
 position = Vector2(279, 364)

--- a/Scripts/Audio/AudioNode.gd
+++ b/Scripts/Audio/AudioNode.gd
@@ -86,6 +86,16 @@ func set_switch(sw_name: String, value: String) -> void:
 	Wwise.set_switch(sw_name, value, _target)
 
 
+func safely_set_switch(sw_name: String, value: String) -> void:
+	if !AK.SWITCHES._dict.has(sw_name):
+		printerr("Unknown switch name: %s" % [sw_name])
+		return
+	if !AK.SWITCHES[sw_name]["SWITCH"].has[value]:
+		printerr("Unknown switch value: %s.%s" % [sw_name, value])
+		return
+	self.set_switch(sw_name, value)
+
+
 class EventConfig:
 	extends RefCounted
 

--- a/Scripts/Components/Character.gd
+++ b/Scripts/Components/Character.gd
@@ -177,7 +177,6 @@ func _process(delta: float) -> void:
 	_maybe_report_env_material()
 
 
-
 #region sensor / target managementregion
 func _on_interaction_sensor_entered(area: Area2D) -> void:
 	if area is Interactable:

--- a/Scripts/Components/Character.gd
+++ b/Scripts/Components/Character.gd
@@ -139,6 +139,8 @@ func _ready() -> void:
 		if id != "":
 			_audio_node.setup(self, id)
 			_audio_node.track_position = true
+			if _state_machine != null:
+				_state_machine.enter.connect(_on_state_enter)
 
 	_state_machine.setup(ctx)
 
@@ -173,6 +175,7 @@ func _process(delta: float) -> void:
 				use_item(Enums.GearSlot.RIGHT)
 
 	_maybe_report_env_material()
+
 
 
 #region sensor / target managementregion
@@ -332,6 +335,19 @@ func _load_gear(data: Dictionary) -> void:
 #region audio
 func is_audio_object() -> bool:
 	return _audio_node != null
+
+
+func audio_node() -> AudioNode:
+	return _audio_node
+
+
+func _on_state_enter(state_name: String) -> void:
+	if !is_audio_object():
+		return
+
+	var sw_name := "%s_StateSwitch" % [id.to_lower()]
+	var sw_value := state_name.to_lower()
+	_audio_node.safely_set_switch(sw_name, sw_value)
 
 
 func _maybe_report_env_material() -> void:

--- a/Scripts/Components/CharacterControl/StateMachine.gd
+++ b/Scripts/Components/CharacterControl/StateMachine.gd
@@ -1,6 +1,8 @@
 class_name StateMachine
 extends Node
 
+signal enter(state_name: String)
+
 @export var _initial_state: State
 var print_state_changes: bool = false
 
@@ -50,6 +52,7 @@ func _switch(next: StateChange, depth: int = 0) -> void:
 				% [depth]
 			)
 		)
+		enter.emit(_cur_state.name)
 		return
 
 	if _cur_state != null:
@@ -63,7 +66,8 @@ func _switch(next: StateChange, depth: int = 0) -> void:
 	var maybe_next: StateChange = await _cur_state.enter(next.ctx)
 	if maybe_next != null:
 		_switch(maybe_next, depth + 1)
-
+	else:
+		enter.emit(_cur_state.name)
 
 func run_input(event: InputEvent) -> void:
 	if !_setup_complete:
@@ -101,5 +105,5 @@ func input_exclusive() -> bool:
 class CharacterContext:
 	extends RefCounted
 
-	var character: CharacterBody2D
+	var character: Character
 	var controller: ControllerBase

--- a/Scripts/Components/CharacterControl/StateMachine.gd
+++ b/Scripts/Components/CharacterControl/StateMachine.gd
@@ -69,6 +69,7 @@ func _switch(next: StateChange, depth: int = 0) -> void:
 	else:
 		enter.emit(_cur_state.name)
 
+
 func run_input(event: InputEvent) -> void:
 	if !_setup_complete:
 		return

--- a/Scripts/DialogicAdapter.gd
+++ b/Scripts/DialogicAdapter.gd
@@ -125,6 +125,10 @@ class QuestAdapter:
 	func _init(id: String) -> void:
 		_id = id
 
+	func is_active() -> bool:
+		var qst := Driver.instance().quest_mgr.quest_by_id(_id)
+		return qst.state == Enums.QuestState.ACTIVE
+
 	func is_finished() -> bool:
 		var qst := Driver.instance().quest_mgr.quest_by_id(_id)
 		return qst.is_finished()

--- a/Scripts/Resources/Effects/ItemPickupEffect.gd
+++ b/Scripts/Resources/Effects/ItemPickupEffect.gd
@@ -10,7 +10,7 @@ extends Effect
 @export var item: ItemStack
 
 
-func act(actor_id: String, _level: LevelBase) -> Variant:
+func act(actor_id: String, level: LevelBase) -> Variant:
 	var inv_manager: InventoryManager = Driver.instance().inventory_mgr
 	var item_node := parent.get_node(dest_path) as Node2D
 
@@ -18,4 +18,16 @@ func act(actor_id: String, _level: LevelBase) -> Variant:
 	if inventory.insert(item):
 		item_node.picked_up.emit()
 		item_node.queue_free()
+
+	var actor_obj := level.get_by_id(actor_id)
+	if actor_obj is Character:
+		var actor_char := actor_obj as Character
+		var audio_node := actor_char.audio_node()
+		if audio_node != null:
+			var event_name := "play_IN_%s_pickup" % [item.item.id.to_lower()]
+			if AK.EVENTS._dict.has(event_name):
+				var cfg := AudioNode.EventConfig.new()
+				cfg.event_name = event_name
+				audio_node.post_event(cfg)
+
 	return null

--- a/Scripts/Resources/Items/Satchel.tres
+++ b/Scripts/Resources/Items/Satchel.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="Item" load_steps=3 format=3 uid="uid://bjjqkmtq6eybl"]
+
+[ext_resource type="Script" path="res://Scripts/Components/Inventory/Item.gd" id="1_1fkxu"]
+[ext_resource type="Texture2D" uid="uid://dvxmx5j5n6yy3" path="res://Art/Items/Satchel.png" id="1_qaxvh"]
+
+[resource]
+script = ExtResource("1_1fkxu")
+id = "SATCHEL"
+name = "Sachel"
+type = 0
+description = "Test item"
+stackable = false
+stack_size = 1
+icon = ExtResource("1_qaxvh")
+gear_spec = Array[Resource("res://Scripts/Resources/GearSpec.gd")]([])


### PR DESCRIPTION
- new dialagic function: `quest.is_active()`
- new event/switch behavior
  - item pickups emit `play_IN_<itemid>_pickup` where `<itemid>` is the full item id lowercased, e.g., when the player picks up `BAG_OF_HARDTACK` we'll emit `play_IN_bag_of_hardtack_pickup`
  - character state changes will set a switch named `<characterid>_StateSwitch` with the current lowercased state name. `<characterid>` is the character's id lowercased:
    - standing: `devin_StateSwitch` -> `idle`
    - walking: `devin_StateSwitch` -> `walk`
    - sprinting: `devin_StateSwitch` -> `sprint`

The current list of devin's states are visible in scene tree of `Devin.tscn`:

<img width="384" height="465" alt="image" src="https://github.com/user-attachments/assets/70d19c85-3349-4915-b846-69d6702a144b" />
